### PR TITLE
Fixed spelling mistake in the spill.md file (eng)

### DIFF
--- a/hetu-docs/en/admin/spill.md
+++ b/hetu-docs/en/admin/spill.md
@@ -68,11 +68,11 @@ is enabled, if there is not enough memory, intermediate cumulated aggregation re
 
 ### Order By
 
-If you're trying to sort a larger amount of data, a significant amount of memory may be needed. When spill to disk for order by is enabled, if there is not enough memory, intemediate sorted results are written to disk. They are loaded back and merged with a lower memory footprint.
+If you're trying to sort a larger amount of data, a significant amount of memory may be needed. When spill to disk for order by is enabled, if there is not enough memory, intermediate sorted results are written to disk. They are loaded back and merged with a lower memory footprint.
 
 ### Window functions
 
-Window Functions perform an operators over a window of rows and return one value for each row. If this window of rows is large, a significant amount of memory may be needed. When spill to disk for window functions is enabled, if there is not enough memory, intemediate sorted results are written to disk. They are loaded back and merged when memory is available. There is a current limitation that spill will not work in all cases such as when a single window is very large.
+Window Functions perform an operators over a window of rows and return one value for each row. If this window of rows is large, a significant amount of memory may be needed. When spill to disk for window functions is enabled, if there is not enough memory, intermediate sorted results are written to disk. They are loaded back and merged when memory is available. There is a current limitation that spill will not work in all cases such as when a single window is very large.
 
 ### Reuse Exchange
 


### PR DESCRIPTION
Fixed spelling mistake in the spill.md file (eng)

### What type of PR is this?

Uncomment only one /kind <> line, hit enter to put that in a new line, and remove leading whitespaces from that line:

/kind bug 

### What does this PR do / why do we need it:
Fixed spelling mistakes

### Which issue(s) this PR fixes:

Fixes #43 

### Special notes for your reviewers: