### PR TITLE
[79] [I44VUV] Fix Dynamic Filters Issue when ORC Predicate Pushdown is enabled

### DIFF
--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q67.push.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q67.push.plan.txt
@@ -6,19 +6,17 @@ local exchange (GATHER, SINGLE, [])
                     local exchange (REPARTITION, HASH, ["d_moy$gid", "d_qoy$gid", "d_year$gid", "groupid", "i_brand$gid", "i_category$gid", "i_class$gid", "i_product_name$gid", "s_store_id$gid"])
                         remote exchange (REPARTITION, HASH, ["d_moy$gid", "d_qoy$gid", "d_year$gid", "groupid", "i_brand$gid", "i_category$gid", "i_class$gid", "i_product_name$gid", "s_store_id$gid"])
                             partial hashaggregation over (d_moy$gid, d_qoy$gid, d_year$gid, groupid, i_brand$gid, i_category$gid, i_class$gid, i_product_name$gid, s_store_id$gid)
-                                local exchange (REPARTITION, HASH, ["i_brand", "i_category", "i_class", "i_product_name"])
-                                    remote exchange (REPARTITION, HASH, ["i_brand", "i_category", "i_class", "i_product_name"])
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["ss_item_sk"])
-                                                join (INNER, REPLICATED):
-                                                    join (INNER, REPLICATED):
-                                                        scan store_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim (pushdown = true)
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan store
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ss_item_sk"])
+                                        join (INNER, REPLICATED):
+                                            join (INNER, REPLICATED):
+                                                scan store_sales
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim (pushdown = true)
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["i_item_sk"])
-                                                    scan item
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan store
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["i_item_sk"])
+                                            scan item

--- a/presto-main/src/main/java/io/prestosql/cost/TableScanStatsRule.java
+++ b/presto-main/src/main/java/io/prestosql/cost/TableScanStatsRule.java
@@ -81,7 +81,7 @@ public class TableScanStatsRule
         Map<ColumnHandle, Symbol> assignments = ImmutableBiMap.copyOf(node.getAssignments()).inverse();
 
         boolean isPredicatesPushDown = false;
-        if (predicate.isAll()
+        if ((predicate.isAll() || predicate.getDomains().get().equals(node.getEnforcedConstraint().getDomains().get()))
                 && !(node.getEnforcedConstraint().isAll() || node.getEnforcedConstraint().isNone())) {
             predicate = node.getEnforcedConstraint();
             isPredicatesPushDown = true;


### PR DESCRIPTION
### What type of PR is this?

kind bug

### What does this PR do / why do we need it: This fixes  issue in creation of dynamic filters when orc predicate pushdown is enabled.

### Which issue(s) this PR fixes:

Fixes #79 #I44VUV

### Special notes for your reviewers: