### PR TITLE
[#91] Integer overflow when parsing dates beyond representable range

### DIFF
--- a/presto-main/src/main/java/io/prestosql/type/DateOperators.java
+++ b/presto-main/src/main/java/io/prestosql/type/DateOperators.java
@@ -147,7 +147,7 @@ public final class DateOperators
         try {
             return parseDate(trim(value).toStringUtf8());
         }
-        catch (IllegalArgumentException e) {
+        catch (IllegalArgumentException | ArithmeticException e) {
             throw new PrestoException(INVALID_CAST_ARGUMENT, "Value cannot be cast to date: " + value.toStringUtf8(), e);
         }
     }

--- a/presto-main/src/test/java/io/prestosql/type/TestDateTimeOperators.java
+++ b/presto-main/src/test/java/io/prestosql/type/TestDateTimeOperators.java
@@ -409,6 +409,12 @@ public class TestDateTimeOperators
         assertInvalidFunction("DATE '392251590-07-12'", INVALID_CAST_ARGUMENT, "Value cannot be cast to date: 392251590-07-12");
     }
 
+    @Test
+    public void testDateCastParse()
+    {
+        assertInvalidFunction("DATE '5881580-07-12'", INVALID_CAST_ARGUMENT, "Value cannot be cast to date: 5881580-07-12");
+    }
+
     private static SqlDate toDate(DateTime dateTime)
     {
         return new SqlDate((int) TimeUnit.MILLISECONDS.toDays(dateTime.getMillis()));

--- a/presto-spi/src/main/java/io/prestosql/spi/util/DateTimeUtils.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/util/DateTimeUtils.java
@@ -37,6 +37,7 @@ import static io.prestosql.spi.util.DateTimeZoneIndex.getDateTimeZone;
 import static io.prestosql.spi.util.DateTimeZoneIndex.packDateTimeWithZone;
 import static io.prestosql.spi.util.DateTimeZoneIndex.unpackChronology;
 import static io.prestosql.spi.util.DateTimeZoneIndex.unpackDateTimeZone;
+import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 
 public final class DateTimeUtils
@@ -49,7 +50,7 @@ public final class DateTimeUtils
 
     public static int parseDate(String value)
     {
-        return (int) TimeUnit.MILLISECONDS.toDays(DATE_FORMATTER.parseMillis(value));
+        return toIntExact(TimeUnit.MILLISECONDS.toDays(DATE_FORMATTER.parseMillis(value)));
     }
 
     public static String printDate(int days)


### PR DESCRIPTION
### What type of PR is this?

Uncomment only one /kind <> line, hit enter to put that in a new line, and remove leading whitespaces from that line:

/kind bug 

### What does this PR do / why do we need it:
Integer overflow when parsing dates beyond representable
### Which issue(s) this PR fixes:

Fixes #91 

### Special notes for your reviewers: