### PR TITLE
Inconsistent error reporting when schema does not exist

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/rewrite/ShowQueriesRewrite.java
+++ b/presto-main/src/main/java/io/prestosql/sql/rewrite/ShowQueriesRewrite.java
@@ -517,6 +517,12 @@ final class ShowQueriesRewrite
         {
             QualifiedObjectName tableName = createQualifiedObjectName(session, showColumns, showColumns.getTable());
 
+            if (!metadata.getCatalogHandle(session, tableName.getCatalogName()).isPresent()) {
+                throw new SemanticException(MISSING_CATALOG, showColumns, "Catalog '%s' does not exist", tableName.getCatalogName());
+            }
+            if (!metadata.schemaExists(session, new CatalogSchemaName(tableName.getCatalogName(), tableName.getSchemaName()))) {
+                throw new SemanticException(MISSING_SCHEMA, showColumns, "Schema '%s' does not exist", tableName.getSchemaName());
+            }
             if (!metadata.getView(session, tableName).isPresent() &&
                     !metadata.getTableHandle(session, tableName).isPresent()) {
                 throw new SemanticException(MISSING_TABLE, showColumns, "Table '%s' does not exist", tableName);

--- a/presto-tpcds/src/test/java/io/prestosql/plugin/tpcds/TestTpcds.java
+++ b/presto-tpcds/src/test/java/io/prestosql/plugin/tpcds/TestTpcds.java
@@ -84,6 +84,14 @@ public class TestTpcds
         assertQueryFails("SHOW TABLES FROM sf0", "line 1:1: Schema 'sf0' does not exist");
     }
 
+    @Test
+    public void testShowColumnsInvalidSchemaCatalog()
+            throws Exception
+    {
+        assertQueryFails("SHOW COLUMNS FROM tpch1.non_existent", ".* Schema 'tpch1' does not exist");
+        assertQueryFails("SHOW COLUMNS FROM xyz.tpch1.non_existent", ".* Catalog 'xyz' does not exist");
+    }
+
     private Session createSession(String schemaName)
     {
         return testSessionBuilder()


### PR DESCRIPTION
### What type of PR is this?
/kind bug 

### What does this PR do / why do we need it:
Inconsistent error reporting when schema does not exist

### Which issue(s) this PR fixes:


Fixes #94

### Special notes for your reviewers: