### PR TITLE
[102] [I29SBC]Support select ArrayType in Elastic Search connector

### DIFF
--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchPageSource.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchPageSource.java
@@ -322,7 +322,7 @@ public class ElasticsearchPageSource
         }
         if (type instanceof ArrayType) {
             Type elementType = ((ArrayType) type).getElementType();
-            return new ArrayDecoder(path, createDecoder(path, elementType));
+            return new ArrayDecoder(createDecoder(path, elementType));
         }
 
         throw new UnsupportedOperationException("Type not supported: " + type);


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What does this PR do / why do we need it:
It supports select Array Type in Elastic Search Connector in OLK

### Which issue(s) this PR fixes:

Fixes #102   #I29SBC

### Special notes for your reviewers: