### PR TITLE
Spelling Correction in doc elasticsearch.md

### DIFF
--- a/hetu-docs/en/connector/elasticsearch.md
+++ b/hetu-docs/en/connector/elasticsearch.md
@@ -192,4 +192,4 @@ The array fields of this structure can be defined by using the following command
     
 ## Limitations
 1. openLooKeng does not support to query table in Elasticsearch which has duplicated columns, such as column "name" and "NAME";
-2. opneLooKeng does not support to query the table in Elasticsearch that the name has special characters, such as '-', '.', etc.
+2. openLooKeng does not support to query the table in Elasticsearch that the name has special characters, such as '-', '.', etc.


### PR DESCRIPTION
### What type of PR is this?

Uncomment only one /kind <> line, hit enter to put that in a new line, and remove leading whitespaces from that line:

kind bug 

### What does this PR do / why do we need it:
Spelling correction in elasticsearch.md change to openLooKeng instead of opneLooKeng

### Which issue(s) this PR fixes:

Fixes #109 

### Special notes for your reviewers: