### PR TITLE
Support Hive tables with customized delimiters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1023,6 +1023,12 @@
                 <artifactId>hadoop-distcp</artifactId>
                 <version>2.10.1</version>
             </dependency>
+
+            <dependency>
+                <groupId>org.apache.hive</groupId>
+                <artifactId>hive-contrib</artifactId>
+                <version>3.1.2</version>
+            </dependency>
             
             <dependency>
                 <groupId>org.apache.hudi</groupId>

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -199,6 +199,17 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-contrib</artifactId>
+            <exclusions>
+                <exclusion>
+                    <artifactId>*</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.cloud.bigdataoss</groupId>
             <artifactId>gcs-connector</artifactId>
         </dependency>

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
@@ -192,6 +192,7 @@ import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.hadoop.hive.metastore.TableType.EXTERNAL_TABLE;
 import static org.apache.hadoop.hive.metastore.TableType.MANAGED_TABLE;
+import static org.apache.hadoop.hive.serde.serdeConstants.FIELD_DELIM;
 import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category.PRIMITIVE;
 
 public class HiveMetadata
@@ -926,6 +927,16 @@ public class HiveMetadata
 
         // Table comment property
         tableMetadata.getComment().ifPresent(value -> tableProperties.put(TABLE_COMMENT, value));
+
+        // field delimiter
+        Object fieldDelimit = tableMetadata.getProperties().get(FIELD_DELIM);
+        if (hiveStorageFormat.equals(HiveStorageFormat.MULTIDELIMIT) && fieldDelimit == null) {
+            throw new PrestoException(INVALID_TABLE_PROPERTY, "This table does not have serde property \"field.delim\"!");
+        }
+        if (fieldDelimit != null) {
+            checkFormatForProperty(hiveStorageFormat, HiveStorageFormat.MULTIDELIMIT, FIELD_DELIM);
+            tableProperties.put(FIELD_DELIM, fieldDelimit.toString());
+        }
 
         return tableProperties.build();
     }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveStorageFormat.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveStorageFormat.java
@@ -16,6 +16,7 @@ package io.prestosql.plugin.hive;
 import io.airlift.units.DataSize;
 import io.airlift.units.DataSize.Unit;
 import io.prestosql.spi.PrestoException;
+import org.apache.hadoop.hive.contrib.serde2.MultiDelimitSerDe;
 import org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat;
 import org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat;
 import org.apache.hadoop.hive.ql.io.RCFileInputFormat;
@@ -93,6 +94,11 @@ public enum HiveStorageFormat
             new DataSize(8, Unit.MEGABYTE)),
     CSV(
             OpenCSVSerde.class.getName(),
+            TextInputFormat.class.getName(),
+            HiveIgnoreKeyTextOutputFormat.class.getName(),
+            new DataSize(8, Unit.MEGABYTE)),
+    MULTIDELIMIT(
+            MultiDelimitSerDe.class.getName(),
             TextInputFormat.class.getName(),
             HiveIgnoreKeyTextOutputFormat.class.getName(),
             new DataSize(8, Unit.MEGABYTE));

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveTableProperties.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveTableProperties.java
@@ -42,6 +42,7 @@ import static io.prestosql.spi.session.PropertyMetadata.stringProperty;
 import static io.prestosql.spi.type.TypeSignature.parseTypeSignature;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
+import static org.apache.hadoop.hive.serde.serdeConstants.FIELD_DELIM;
 
 public class HiveTableProperties
 {
@@ -162,6 +163,11 @@ public class HiveTableProperties
                         TRANSACTIONAL,
                         "Is transactional property enabled",
                         false,
+                        false),
+                stringProperty(
+                        FIELD_DELIM,
+                        format("Field Delimiter for the table"),
+                        null,
                         false));
     }
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
@@ -183,6 +183,7 @@ import static io.prestosql.plugin.hive.HiveMetadata.convertToPredicate;
 import static io.prestosql.plugin.hive.HiveStorageFormat.AVRO;
 import static io.prestosql.plugin.hive.HiveStorageFormat.CSV;
 import static io.prestosql.plugin.hive.HiveStorageFormat.JSON;
+import static io.prestosql.plugin.hive.HiveStorageFormat.MULTIDELIMIT;
 import static io.prestosql.plugin.hive.HiveStorageFormat.ORC;
 import static io.prestosql.plugin.hive.HiveStorageFormat.PARQUET;
 import static io.prestosql.plugin.hive.HiveStorageFormat.RCBINARY;
@@ -435,7 +436,7 @@ public abstract class AbstractTestHive
     protected Set<HiveStorageFormat> createTableFormats = difference(
             ImmutableSet.copyOf(HiveStorageFormat.values()),
             // exclude formats that change table schema with serde
-            ImmutableSet.of(AVRO, CSV));
+            ImmutableSet.of(AVRO, CSV, MULTIDELIMIT));
 
     private static final JoinCompiler JOIN_COMPILER = new JoinCompiler(createTestMetadataManager());
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHivePageSink.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHivePageSink.java
@@ -110,8 +110,9 @@ public class TestHivePageSink
         try {
             HiveMetastore metastore = createTestingFileHiveMetastore(new File(tempDir, "metastore"));
             for (HiveStorageFormat format : HiveStorageFormat.values()) {
-                if (format == HiveStorageFormat.CSV) {
+                if (format == HiveStorageFormat.CSV || format == HiveStorageFormat.MULTIDELIMIT) {
                     // CSV supports only unbounded VARCHAR type, which is not provided by lineitem
+                    // MULTIDELIMIT is supported only when field.delim property is specified
                     continue;
                 }
                 config.setHiveStorageFormat(format);


### PR DESCRIPTION
### What type of PR is this?

Uncomment only one /kind <> line, hit enter to put that in a new line, and remove leading whitespaces from that line:

kind bug

### What does this PR do / why do we need it: Support Hive tables with customized delimiters

### Which issue(s) this PR fixes:

Fixes #118 #I455PL

### Special notes for your reviewers: