### PR TITLE
[124] [I3BXGG] Output is not same as hive when data contains '\0'

### DIFF
--- a/presto-cli/src/main/java/io/prestosql/cli/Pager.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/Pager.java
@@ -73,7 +73,9 @@ public class Pager
             throws IOException
     {
         try {
-            super.write(b);
+            if (b != 0) {
+                super.write(b);
+            }
         }
         catch (IOException e) {
             throw propagateIOException(e);

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -528,6 +528,12 @@
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-util</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.3</version>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/util/FieldSetterFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/util/FieldSetterFactory.java
@@ -61,6 +61,7 @@ import static io.prestosql.plugin.hive.HiveWriteUtils.getHiveDecimal;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
+import static org.apache.commons.text.StringEscapeUtils.unescapeJava;
 
 public final class FieldSetterFactory
 {
@@ -299,7 +300,12 @@ public final class FieldSetterFactory
         public void setField(Block block, int position)
         {
             value.set(type.getSlice(block, position).getBytes());
-            rowInspector.setStructFieldData(row, field, value);
+            rowInspector.setStructFieldData(row, field, unescapeText(value.toString()));
+        }
+
+        private Text unescapeText(String text)
+        {
+            return new Text(unescapeJava(text));
         }
     }
 

--- a/presto-orc/pom.xml
+++ b/presto-orc/pom.xml
@@ -188,6 +188,12 @@
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.3</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/presto-rcfile/pom.xml
+++ b/presto-rcfile/pom.xml
@@ -132,5 +132,11 @@
             <artifactId>lzo-hadoop</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.3</version>
+        </dependency>
     </dependencies>
 </project>

--- a/presto-rcfile/src/main/java/io/prestosql/rcfile/RcFileDecoderUtils.java
+++ b/presto-rcfile/src/main/java/io/prestosql/rcfile/RcFileDecoderUtils.java
@@ -30,6 +30,7 @@ import static io.airlift.slice.SliceUtf8.offsetOfCodePoint;
 import static java.lang.Math.min;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
+import static org.apache.commons.text.StringEscapeUtils.unescapeJava;
 
 // faster versions of org.apache.hadoop.io.WritableUtils methods adapted for Slice
 public final class RcFileDecoderUtils
@@ -266,5 +267,10 @@ public final class RcFileDecoderUtils
             return length;
         }
         return indexEnd - offset;
+    }
+
+    public static String unescapeText(String text)
+    {
+        return unescapeJava(text);
     }
 }

--- a/presto-rcfile/src/main/java/io/prestosql/rcfile/binary/StringEncoding.java
+++ b/presto-rcfile/src/main/java/io/prestosql/rcfile/binary/StringEncoding.java
@@ -25,6 +25,7 @@ import static io.airlift.slice.Slices.EMPTY_SLICE;
 import static io.prestosql.rcfile.RcFileDecoderUtils.calculateTruncationLength;
 import static io.prestosql.rcfile.RcFileDecoderUtils.decodeVIntSize;
 import static io.prestosql.rcfile.RcFileDecoderUtils.readVInt;
+import static io.prestosql.rcfile.RcFileDecoderUtils.unescapeText;
 import static io.prestosql.rcfile.RcFileDecoderUtils.writeVInt;
 import static java.lang.Math.toIntExact;
 
@@ -50,7 +51,13 @@ public class StringEncoding
                     output.writeByte(HIVE_EMPTY_STRING_BYTE);
                 }
                 else {
-                    output.writeBytes(slice);
+                    String escapedValue = unescapeText(new String(slice.getBytes()));
+                    if (escapedValue.getBytes().length < slice.getBytes().length) {
+                        output.writeBytes(escapedValue.getBytes());
+                    }
+                    else {
+                        output.writeBytes(slice);
+                    }
                 }
             }
             encodeOutput.closeEntry();

--- a/presto-rcfile/src/main/java/io/prestosql/rcfile/text/StringEncoding.java
+++ b/presto-rcfile/src/main/java/io/prestosql/rcfile/text/StringEncoding.java
@@ -23,6 +23,7 @@ import io.prestosql.spi.block.BlockBuilder;
 import io.prestosql.spi.type.Type;
 
 import static io.prestosql.rcfile.RcFileDecoderUtils.calculateTruncationLength;
+import static io.prestosql.rcfile.RcFileDecoderUtils.unescapeText;
 
 public class StringEncoding
         implements TextColumnEncoding
@@ -50,7 +51,13 @@ public class StringEncoding
                 if (escapeByte != null && slice.indexOfByte(escapeByte) < 0) {
                     throw new IllegalArgumentException("escape not implemented");
                 }
-                output.writeBytes(slice);
+                String escapedValue = unescapeText(new String(slice.getBytes()));
+                if (escapedValue.getBytes().length < slice.getBytes().length) {
+                    output.writeBytes(escapedValue.getBytes());
+                }
+                else {
+                    output.writeBytes(slice);
+                }
             }
             encodeOutput.closeEntry();
         }


### PR DESCRIPTION
### What type of PR is this?

/kind feature

### What does this PR do / why do we need it:

Fixes the output when data contains '\0'

### Which issue(s) this PR fixes:

Fixes #124  #I3BXGG

### Special notes for your reviewers: