### PR TITLE
Spill Prefetch Read and Prioritizing Larger splits in Memory Revoke

### DIFF
--- a/hetu-docs/en/admin/properties.md
+++ b/hetu-docs/en/admin/properties.md
@@ -240,6 +240,34 @@ This section describes the most important config properties that may be used to 
 >
 > Enables using a randomly generated secret key (per spill file) to encrypt and decrypt data spilled to disk
 
+### `experimental.spill-direct-serde-enabled`
+
+> -   **Type:** `boolean`
+> -   **Default value:** `false`
+>
+> Enables to serialize/read the page directly to/from the stream.
+
+### `experimental.spill-prefetch-read-pages`
+
+> -   **Type:** `integer`
+> -   **Default value:** `1`
+>
+> Sets number of pages prefetched while reading from spilled files.
+
+### `experimental.revocable-memory-selection-threshold`
+
+> -   **Type:** `data size`
+> -   **Default value:** `512 MB`
+>
+> Sets memory selection threshold for revocable memory of operator to directly allocate revocable memory for remaining bytes ready to revoke. 
+
+### `experimental.prioritize-larger-spilts-memory-revoke`
+
+> -   **Type:** `boolean`
+> -   **Default value:** `true`
+>
+> Enables to prioritize splits with larger revocable memory.
+
 ## Exchange Properties
 
 Exchanges transfer data between openLooKeng nodes for different stages of a query. Adjusting these properties may help to resolve inter-node communication issues or improve network utilization.

--- a/presto-cli/src/main/java/io/prestosql/cli/StatusPrinter.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/StatusPrinter.java
@@ -206,11 +206,11 @@ Spilled: 20GB
             // Peak Memory: 1.97GB
             reprintLine("Peak Memory: " + FormatUtils.formatDataSize(bytes(stats.getPeakMemoryBytes()), true));
 
-            // Spilled Data: 20GB, Writing Time: 22s, Reading Time: 1.2s
+            // Spilled Data: 20GB, Writing Time Per Node: 22s, Reading Time Per Node: 1.2s
             if (stats.getSpilledBytes() > 0) {
-                Duration readTime = millis(stats.getElapsedSpillReadTimeMillis());
-                Duration writeTime = millis(stats.getElapsedSpillWriteTimeMillis());
-                String summary = String.format("Spilled: %s, Writing Time: %.1fs, Reading Time: %.1fs",
+                Duration readTime = millis(stats.getElapsedSpillReadTimeMillis() / stats.getSpilledNodes());
+                Duration writeTime = millis(stats.getElapsedSpillWriteTimeMillis() / stats.getSpilledNodes());
+                String summary = String.format("Spilled: %s, Writing Time Per Node: %.1fs, Reading Time Per Node: %.1fs",
                         FormatUtils.formatDataSize(bytes(stats.getSpilledBytes()), true),
                         writeTime.getValue(SECONDS),
                         readTime.getValue(SECONDS));
@@ -310,8 +310,8 @@ Spilled: 20GB
 
                 // Spilled Data: 20GB, Writing Time: 25s, Reading Time: 8s
                 if (stats.getSpilledBytes() > 0) {
-                    Duration readTime = millis(stats.getElapsedSpillReadTimeMillis());
-                    Duration writeTime = millis(stats.getElapsedSpillWriteTimeMillis());
+                    Duration readTime = millis(stats.getElapsedSpillReadTimeMillis() / stats.getSpilledNodes());
+                    Duration writeTime = millis(stats.getElapsedSpillWriteTimeMillis() / stats.getSpilledNodes());
                     String summary = String.format("Spilled: %s, Writing Time: %.1fs, Reading Time: %.1fs",
                             FormatUtils.formatDataSize(bytes(stats.getSpilledBytes()), true),
                             writeTime.getValue(SECONDS),

--- a/presto-client/src/main/java/io/prestosql/client/StatementStats.java
+++ b/presto-client/src/main/java/io/prestosql/client/StatementStats.java
@@ -46,6 +46,7 @@ public class StatementStats
     private final long spilledBytes;
     private long elapsedSpillReadTimeMillis;
     private long elapsedSpillWriteTimeMillis;
+    private int spilledNodes;
     private final StageStats rootStage;
 
     @JsonCreator
@@ -68,6 +69,7 @@ public class StatementStats
             @JsonProperty("spilledBytes") long spilledBytes,
             @JsonProperty("elapsedSpillReadTimeMillis") long elapsedSpillReadTimeMillis,
             @JsonProperty("elapsedSpillWriteTimeMillis") long elapsedSpillWriteTimeMillis,
+            @JsonProperty("spilledNodes") int spilledNodes,
             @JsonProperty("rootStage") StageStats rootStage)
     {
         this.state = requireNonNull(state, "state is null");
@@ -88,6 +90,7 @@ public class StatementStats
         this.spilledBytes = spilledBytes;
         this.elapsedSpillReadTimeMillis = elapsedSpillReadTimeMillis;
         this.elapsedSpillWriteTimeMillis = elapsedSpillWriteTimeMillis;
+        this.spilledNodes = spilledNodes;
         this.rootStage = rootStage;
     }
 
@@ -215,6 +218,12 @@ public class StatementStats
         return elapsedSpillWriteTimeMillis;
     }
 
+    @JsonProperty
+    public int getSpilledNodes()
+    {
+        return spilledNodes;
+    }
+
     @Override
     public String toString()
     {
@@ -267,6 +276,7 @@ public class StatementStats
         private StageStats rootStage;
         private long spillReadTimeMillis;
         private long spillWriteTimeMillis;
+        private int spilledNodes;
 
         private Builder() {}
 
@@ -378,6 +388,12 @@ public class StatementStats
             return this;
         }
 
+        public Builder setSpilledNodes(int spilledNodes)
+        {
+            this.spilledNodes = spilledNodes;
+            return this;
+        }
+
         public Builder setRootStage(StageStats rootStage)
         {
             this.rootStage = rootStage;
@@ -405,6 +421,7 @@ public class StatementStats
                     spilledBytes,
                     spillReadTimeMillis,
                     spillWriteTimeMillis,
+                    spilledNodes,
                     rootStage);
         }
     }

--- a/presto-jdbc/src/test/java/io/prestosql/jdbc/TestProgressMonitor.java
+++ b/presto-jdbc/src/test/java/io/prestosql/jdbc/TestProgressMonitor.java
@@ -90,7 +90,7 @@ public class TestProgressMonitor
                 nextUriId == null ? null : server.url(format("/v1/statement/%s/%s", queryId, nextUriId)).uri(),
                 responseColumns,
                 data,
-                new StatementStats(state, state.equals("QUEUED"), true, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null),
+                new StatementStats(state, state.equals("QUEUED"), true, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null),
                 null,
                 ImmutableList.of(),
                 null,

--- a/presto-main/src/main/java/io/prestosql/operator/OperatorContext.java
+++ b/presto-main/src/main/java/io/prestosql/operator/OperatorContext.java
@@ -398,6 +398,17 @@ public class OperatorContext
         return memoryRevokingRequested;
     }
 
+    public long getRevocableMemory()
+    {
+        long revocableMemory = 0L;
+        synchronized (this) {
+            if (operatorMemoryContext.getRevocableMemory() > 0) {
+                revocableMemory = operatorMemoryContext.getRevocableMemory();
+            }
+        }
+        return revocableMemory;
+    }
+
     /**
      * Returns how much revocable memory will be revoked by the operator
      */

--- a/presto-main/src/main/java/io/prestosql/server/protocol/PagePublisherQueryManager.java
+++ b/presto-main/src/main/java/io/prestosql/server/protocol/PagePublisherQueryManager.java
@@ -62,7 +62,7 @@ public class PagePublisherQueryManager
     private final Set<String> queries = Sets.newConcurrentHashSet();
     private final Map<String, PagePublisherQueryRunner> queryRunners = new ConcurrentHashMap<>();
     private static final DataCenterQueryResults FINISHED_RESULTS_DONOT_USE_HEADER = new DataCenterQueryResults("", URI.create(""), null, null, null, null,
-            new StatementStats("FINISHED", false, false, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null), null,
+            new StatementStats("FINISHED", false, false, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null), null,
             Collections.emptyList(), null, false);
 
     private final DispatchManager dispatchManager;

--- a/presto-main/src/main/java/io/prestosql/server/protocol/PagePublisherQueryRunner.java
+++ b/presto-main/src/main/java/io/prestosql/server/protocol/PagePublisherQueryRunner.java
@@ -69,13 +69,13 @@ public class PagePublisherQueryRunner
     private static final Logger log = Logger.get(PagePublisherQueryRunner.class);
 
     private static final DataCenterQueryResults RUNNING_RESULTS = new DataCenterQueryResults("", URI.create(""), null, URI.create(""), null, null,
-            new StatementStats("RUNNING", false, false, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null), null,
+            new StatementStats("RUNNING", false, false, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null), null,
             Collections.emptyList(), null, true);
     private static final DataCenterQueryResults FINISHED_RESULTS = new DataCenterQueryResults("", URI.create(""), null, null, null, null,
-            new StatementStats("FINISHED", false, false, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null), null,
+            new StatementStats("FINISHED", false, false, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null), null,
             Collections.emptyList(), null, true);
     private static final DataCenterQueryResults FAILED_RESULTS = new DataCenterQueryResults("", URI.create(""), null, null, null, null,
-            new StatementStats("FAILED", false, false, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null), null,
+            new StatementStats("FAILED", false, false, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null), null,
             Collections.emptyList(), null, true);
     private static final Ordering<Comparable<Duration>> WAIT_ORDERING = Ordering.natural().nullsLast();
     private static final Duration MAX_WAIT_TIME = new Duration(1, SECONDS);

--- a/presto-main/src/main/java/io/prestosql/spiller/NodeSpillConfig.java
+++ b/presto-main/src/main/java/io/prestosql/spiller/NodeSpillConfig.java
@@ -16,6 +16,8 @@ package io.prestosql.spiller;
 import io.airlift.configuration.Config;
 import io.airlift.units.DataSize;
 
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 public class NodeSpillConfig
@@ -27,6 +29,8 @@ public class NodeSpillConfig
     private boolean spillEncryptionEnabled;
 
     private boolean spillDirectSerdeEnabled;
+
+    private int spillPrefetchReadPages = 1;
 
     @NotNull
     public DataSize getMaxSpillPerNode()
@@ -87,6 +91,20 @@ public class NodeSpillConfig
     public NodeSpillConfig setSpillDirectSerdeEnabled(boolean spillDirectSerdeEnabled)
     {
         this.spillDirectSerdeEnabled = spillDirectSerdeEnabled;
+        return this;
+    }
+
+    @Min(1)
+    @Max(100)
+    public int getSpillPrefetchReadPages()
+    {
+        return spillPrefetchReadPages;
+    }
+
+    @Config("experimental.spill-prefetch-read-pages")
+    public NodeSpillConfig setSpillPrefetchReadPages(int spillPrefetchedReadPages)
+    {
+        this.spillPrefetchReadPages = spillPrefetchedReadPages;
         return this;
     }
 }

--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/FeaturesConfig.java
@@ -172,6 +172,8 @@ public class FeaturesConfig
     private int prcntDriversForPartialAggr = 5;
     private boolean skipAttachingStatsWithPlan = true;
     private boolean skipNonApplicableRulesEnabled;
+    private boolean prioritizeLargerSpiltsMemoryRevoke = true;
+    private DataSize revocableMemorySelectionThreshold = new DataSize(512, MEGABYTE);
 
     public enum JoinReorderingStrategy
     {
@@ -1399,6 +1401,30 @@ public class FeaturesConfig
     public FeaturesConfig setSkipNonApplicableRulesEnabled(boolean skipNonApplicableRulesEnabled)
     {
         this.skipNonApplicableRulesEnabled = skipNonApplicableRulesEnabled;
+        return this;
+    }
+
+    public boolean isPrioritizeLargerSpiltsMemoryRevoke()
+    {
+        return prioritizeLargerSpiltsMemoryRevoke;
+    }
+
+    @Config("experimental.prioritize-larger-spilts-memory-revoke")
+    public FeaturesConfig setPrioritizeLargerSpiltsMemoryRevoke(boolean prioritizeLargerSpiltsMemoryRevoke)
+    {
+        this.prioritizeLargerSpiltsMemoryRevoke = prioritizeLargerSpiltsMemoryRevoke;
+        return this;
+    }
+
+    public long getRevocableMemorySelectionThreshold()
+    {
+        return revocableMemorySelectionThreshold.toBytes();
+    }
+
+    @Config("experimental.revocable-memory-selection-threshold")
+    public FeaturesConfig setRevocableMemorySelectionThreshold(DataSize revocableMemorySelectionThreshold)
+    {
+        this.revocableMemorySelectionThreshold = revocableMemorySelectionThreshold;
         return this;
     }
 }

--- a/presto-main/src/test/java/io/prestosql/execution/TestMemoryRevokingScheduler.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TestMemoryRevokingScheduler.java
@@ -138,7 +138,7 @@ public class TestMemoryRevokingScheduler
         OperatorContext operatorContext5 = driverContext211.addOperatorContext(5, new PlanNodeId("na"), "na");
 
         Collection<SqlTask> tasks = ImmutableList.of(sqlTask1, sqlTask2);
-        MemoryRevokingScheduler scheduler = new MemoryRevokingScheduler(singletonList(memoryPool), () -> tasks, executor, 1.0, 1.0);
+        MemoryRevokingScheduler scheduler = new MemoryRevokingScheduler(singletonList(memoryPool), () -> tasks, executor, 1.0, 1.0, false, new DataSize(512, MEGABYTE).toBytes());
 
         allOperatorContexts = ImmutableSet.of(operatorContext1, operatorContext2, operatorContext3, operatorContext4, operatorContext5);
         assertMemoryRevokingNotRequested();
@@ -205,7 +205,7 @@ public class TestMemoryRevokingScheduler
         OperatorContext operatorContext2 = createContexts(sqlTask2);
 
         List<SqlTask> tasks = ImmutableList.of(sqlTask1, sqlTask2);
-        MemoryRevokingScheduler scheduler = new MemoryRevokingScheduler(asList(memoryPool, anotherMemoryPool), () -> tasks, executor, 1.0, 1.0);
+        MemoryRevokingScheduler scheduler = new MemoryRevokingScheduler(asList(memoryPool, anotherMemoryPool), () -> tasks, executor, 1.0, 1.0, false, new DataSize(512, MEGABYTE).toBytes());
         allOperatorContexts = ImmutableSet.of(operatorContext1, operatorContext2);
 
         /*
@@ -240,7 +240,7 @@ public class TestMemoryRevokingScheduler
 
         allOperatorContexts = ImmutableSet.of(operatorContext);
         List<SqlTask> tasks = ImmutableList.of(sqlTask);
-        MemoryRevokingScheduler scheduler = new MemoryRevokingScheduler(singletonList(memoryPool), () -> tasks, executor, 1.0, 1.0);
+        MemoryRevokingScheduler scheduler = new MemoryRevokingScheduler(singletonList(memoryPool), () -> tasks, executor, 1.0, 1.0, false, new DataSize(512, MEGABYTE).toBytes());
         scheduler.registerPoolListeners(); // no periodic check initiated
 
         // When

--- a/presto-main/src/test/java/io/prestosql/operator/TestOrderByOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestOrderByOperator.java
@@ -351,7 +351,7 @@ public class TestOrderByOperator
                 createTestMetadataManager().getFunctionAndTypeManager().getBlockEncodingSerde(),
                 new SpillerStats(),
                 ImmutableList.of(spillPath),
-                1.0, false, false, false);
+                1.0, false, false, false, 1);
         return new GenericSpillerFactory(streamSpillerFactory);
     }
 

--- a/presto-main/src/test/java/io/prestosql/operator/TestWindowOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestWindowOperator.java
@@ -1171,7 +1171,7 @@ public class TestWindowOperator
                 createTestMetadataManager().getFunctionAndTypeManager().getBlockEncodingSerde(),
                 new SpillerStats(),
                 ImmutableList.of(spillPath),
-                1.0, false, false, false);
+                1.0, false, false, false, 1);
         return new GenericSpillerFactory(streamSpillerFactory);
     }
 

--- a/presto-main/src/test/java/io/prestosql/operator/spiller/BenchmarkBinaryFileSpiller.java
+++ b/presto-main/src/test/java/io/prestosql/operator/spiller/BenchmarkBinaryFileSpiller.java
@@ -110,6 +110,9 @@ public class BenchmarkBinaryFileSpiller
         @Param("false")
         private boolean directSerdeEnabled;
 
+        @Param("1")
+        private int spillPrefetchReadPages = 1;
+
         private List<Page> pages;
         private Spiller readSpiller;
 
@@ -128,7 +131,8 @@ public class BenchmarkBinaryFileSpiller
                     1.0,
                     compressionEnabled,
                     encryptionEnabled,
-                    directSerdeEnabled);
+                    directSerdeEnabled,
+                    spillPrefetchReadPages);
             spillerFactory = new GenericSpillerFactory(singleStreamSpillerFactory);
             pages = createInputPages();
             readSpiller = spillerFactory.create(TYPES, bytes -> {}, newSimpleAggregatedMemoryContext());

--- a/presto-main/src/test/java/io/prestosql/spiller/TestFileSingleStreamSpiller.java
+++ b/presto-main/src/test/java/io/prestosql/spiller/TestFileSingleStreamSpiller.java
@@ -127,7 +127,7 @@ public class TestFileSingleStreamSpiller
                 1.0,
                 compression,
                 encryption,
-                false);
+                false, 1);
         LocalMemoryContext memoryContext = newSimpleAggregatedMemoryContext().newLocalMemoryContext("test");
         SingleStreamSpiller singleStreamSpiller = spillerFactory.create(TYPES, bytes -> {}, memoryContext);
         assertTrue(singleStreamSpiller instanceof FileSingleStreamSpiller);
@@ -208,7 +208,7 @@ public class TestFileSingleStreamSpiller
                 1.0,
                 compression,
                 encryption,
-                useDirectSerde);
+                useDirectSerde, 1);
         LocalMemoryContext memoryContext = newSimpleAggregatedMemoryContext().newLocalMemoryContext("test");
         long startTime = System.currentTimeMillis();
         Stopwatch spillTimer = Stopwatch.createStarted();
@@ -289,46 +289,64 @@ public class TestFileSingleStreamSpiller
     public void testSpillWithSingleSpillerConsolidatedWithCompression()
             throws Exception
     {
-        assertSpillBenchmarkReadingUsingWorkProcessor(true, false, "1GB", 1, false);
-        assertSpillBenchmarkReadingUsingWorkProcessor(true, false, "1GB", 1, true);
+        assertSpillBenchmarkReadingUsingWorkProcessor(true, false, "1GB", 1, false, 1);
+        assertSpillBenchmarkReadingUsingWorkProcessor(true, false, "1GB", 1, true, 1);
+
+        assertSpillBenchmarkReadingUsingWorkProcessor(true, false, "1GB", 1, false, 25);
+        assertSpillBenchmarkReadingUsingWorkProcessor(true, false, "1GB", 1, true, 25);
     }
 
     @Test
     public void testSpillWithSingleSpillerConsolidatedWithCompressionMultiFile()
             throws Exception
     {
-        assertSpillBenchmarkReadingUsingWorkProcessor(true, false, "2MB", 512, false);
-        assertSpillBenchmarkReadingUsingWorkProcessor(true, false, "2MB", 512, true);
+        assertSpillBenchmarkReadingUsingWorkProcessor(true, false, "2MB", 512, false, 1);
+        assertSpillBenchmarkReadingUsingWorkProcessor(true, false, "2MB", 512, true, 1);
+
+        assertSpillBenchmarkReadingUsingWorkProcessor(true, false, "2MB", 512, false, 25);
+        assertSpillBenchmarkReadingUsingWorkProcessor(true, false, "2MB", 512, true, 25);
     }
 
     @Test
     public void testSpillWithSingleSpillerConsolidatedWithoutCompression()
             throws Exception
     {
-        assertSpillBenchmarkReadingUsingWorkProcessor(false, false, "1GB", 1, false);
-        assertSpillBenchmarkReadingUsingWorkProcessor(false, false, "1GB", 1, true);
+        assertSpillBenchmarkReadingUsingWorkProcessor(false, false, "1GB", 1, false, 1);
+        assertSpillBenchmarkReadingUsingWorkProcessor(false, false, "1GB", 1, true, 1);
+
+        assertSpillBenchmarkReadingUsingWorkProcessor(false, false, "1GB", 1, false, 25);
+        assertSpillBenchmarkReadingUsingWorkProcessor(false, false, "1GB", 1, true, 25);
     }
 
     @Test
     public void testSpillWithSingleSpillerConsolidatedWithoutCompressionMultiFile()
             throws Exception
     {
-        assertSpillBenchmarkReadingUsingWorkProcessor(false, false, "2MB", 512, false);
-        assertSpillBenchmarkReadingUsingWorkProcessor(false, false, "2MB", 512, true);
+        assertSpillBenchmarkReadingUsingWorkProcessor(false, false, "2MB", 512, false, 1);
+        assertSpillBenchmarkReadingUsingWorkProcessor(false, false, "2MB", 512, true, 1);
+
+        assertSpillBenchmarkReadingUsingWorkProcessor(false, false, "2MB", 512, false, 25);
+        assertSpillBenchmarkReadingUsingWorkProcessor(false, false, "2MB", 512, true, 25);
     }
 
     @Test
     public void testSpillWithSingleSpillerConsolidatedWithEncryption()
             throws Exception
     {
-        assertSpillBenchmarkReadingUsingWorkProcessor(false, true, "1GB", 1, false);
-        assertSpillBenchmarkReadingUsingWorkProcessor(false, true, "1GB", 1, true);
+        assertSpillBenchmarkReadingUsingWorkProcessor(false, true, "1GB", 1, false, 1);
+        assertSpillBenchmarkReadingUsingWorkProcessor(false, true, "1GB", 1, true, 1);
 
-        assertSpillBenchmarkReadingUsingWorkProcessor(true, true, "1GB", 1, false);
-        assertSpillBenchmarkReadingUsingWorkProcessor(true, true, "1GB", 1, true);
+        assertSpillBenchmarkReadingUsingWorkProcessor(true, true, "1GB", 1, false, 1);
+        assertSpillBenchmarkReadingUsingWorkProcessor(true, true, "1GB", 1, true, 1);
+
+        assertSpillBenchmarkReadingUsingWorkProcessor(false, true, "1GB", 1, false, 25);
+        assertSpillBenchmarkReadingUsingWorkProcessor(false, true, "1GB", 1, true, 25);
+
+        assertSpillBenchmarkReadingUsingWorkProcessor(true, true, "1GB", 1, false, 25);
+        assertSpillBenchmarkReadingUsingWorkProcessor(true, true, "1GB", 1, true, 25);
     }
 
-    private void assertSpillBenchmarkReadingUsingWorkProcessor(boolean compression, boolean encryption, String pageSize, int fileCount, boolean useDirectSerde)
+    private void assertSpillBenchmarkReadingUsingWorkProcessor(boolean compression, boolean encryption, String pageSize, int fileCount, boolean useDirectSerde, int spillPrefetchReadPages)
             throws Exception
     {
         List<FileSingleStreamSpiller> spillers = new ArrayList<>();
@@ -340,7 +358,8 @@ public class TestFileSingleStreamSpiller
                 1.0,
                 compression,
                 encryption,
-                useDirectSerde);
+                useDirectSerde,
+                spillPrefetchReadPages);
 
         LocalMemoryContext memoryContext = newSimpleAggregatedMemoryContext().newLocalMemoryContext("test");
         long startTime = System.currentTimeMillis();

--- a/presto-main/src/test/java/io/prestosql/spiller/TestFileSingleStreamSpillerFactory.java
+++ b/presto-main/src/test/java/io/prestosql/spiller/TestFileSingleStreamSpillerFactory.java
@@ -87,7 +87,7 @@ public class TestFileSingleStreamSpillerFactory
                 1.0,
                 false,
                 false,
-                false);
+                false, 1);
 
         assertEquals(listFiles(spillPath1.toPath()).size(), 0);
         assertEquals(listFiles(spillPath2.toPath()).size(), 0);
@@ -127,7 +127,7 @@ public class TestFileSingleStreamSpillerFactory
                 0.0,
                 false,
                 false,
-                false);
+                false, 1);
 
         spillerFactory.create(types, bytes -> {}, newSimpleAggregatedMemoryContext().newLocalMemoryContext("test"));
     }
@@ -145,7 +145,7 @@ public class TestFileSingleStreamSpillerFactory
                 1.0,
                 false,
                 false,
-                false);
+                false, 1);
         spillerFactory.create(types, bytes -> {}, newSimpleAggregatedMemoryContext().newLocalMemoryContext("test"));
     }
 
@@ -175,7 +175,7 @@ public class TestFileSingleStreamSpillerFactory
                 1.0,
                 false,
                 false,
-                false);
+                false, 1);
         spillerFactory.cleanupOldSpillFiles();
 
         assertEquals(listFiles(spillPath1.toPath()).size(), 1);

--- a/presto-main/src/test/java/io/prestosql/spiller/TestNodeSpillConfig.java
+++ b/presto-main/src/test/java/io/prestosql/spiller/TestNodeSpillConfig.java
@@ -35,7 +35,8 @@ public class TestNodeSpillConfig
                 .setQueryMaxSpillPerNode(new DataSize(100, GIGABYTE))
                 .setSpillCompressionEnabled(false)
                 .setSpillEncryptionEnabled(false)
-                .setSpillDirectSerdeEnabled(false));
+                .setSpillDirectSerdeEnabled(false)
+                .setSpillPrefetchReadPages(1));
     }
 
     @Test
@@ -47,6 +48,7 @@ public class TestNodeSpillConfig
                 .put("experimental.spill-compression-enabled", "true")
                 .put("experimental.spill-encryption-enabled", "true")
                 .put("experimental.spill-direct-serde-enabled", "true")
+                .put("experimental.spill-prefetch-read-pages", "25")
                 .build();
 
         NodeSpillConfig expected = new NodeSpillConfig()
@@ -54,7 +56,8 @@ public class TestNodeSpillConfig
                 .setQueryMaxSpillPerNode(new DataSize(15, MEGABYTE))
                 .setSpillCompressionEnabled(true)
                 .setSpillEncryptionEnabled(true)
-                .setSpillDirectSerdeEnabled(true);
+                .setSpillDirectSerdeEnabled(true)
+                .setSpillPrefetchReadPages(25);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-main/src/test/java/io/prestosql/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/io/prestosql/sql/analyzer/TestFeaturesConfig.java
@@ -150,7 +150,9 @@ public class TestFeaturesConfig
                 .setSortBasedAggregationEnabled(false)
                 .setPrcntDriversForPartialAggr(5)
                 .setSkipAttachingStatsWithPlan(true)
-                .setSkipNonApplicableRulesEnabled(false));
+                .setSkipNonApplicableRulesEnabled(false)
+                .setPrioritizeLargerSpiltsMemoryRevoke(true)
+                .setRevocableMemorySelectionThreshold(new DataSize(512, MEGABYTE)));
     }
 
     @Test
@@ -253,6 +255,8 @@ public class TestFeaturesConfig
                 .put("sort.prcnt-drivers-for-partial-aggr", "55")
                 .put("optimizer.skip-attaching-stats-with-plan", "false")
                 .put("optimizer.skip-non-applicable-rules-enabled", "true")
+                .put("experimental.prioritize-larger-spilts-memory-revoke", "false")
+                .put("experimental.revocable-memory-selection-threshold", "500MB")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -352,7 +356,9 @@ public class TestFeaturesConfig
                 .setSortBasedAggregationEnabled(true)
                 .setPrcntDriversForPartialAggr(55)
                 .setSkipAttachingStatsWithPlan(false)
-                .setSkipNonApplicableRulesEnabled(true);
+                .setSkipNonApplicableRulesEnabled(true)
+                .setPrioritizeLargerSpiltsMemoryRevoke(false)
+                .setRevocableMemorySelectionThreshold(new DataSize(500, MEGABYTE));
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
### What type of PR is this?

kind task 

### What does this PR do / why do we need it: Prefetch Reads from files and prioritizing larger spilts in memory revoke

### Which issue(s) this PR fixes:

Fixes #157 #I4JUF0

### Special notes for your reviewers:

Query: select * from web_sales  order by ws_sold_time_sk;
Readings were taken with Single spiller thread(experimental.spiller-threads=1)

Readings with Base Code:

Spill Writing time = 2125.60995 ms
Spill reading time = 809.68725 ms

Readings with Modifications:

Spill Writing time = 1709.20986 ms
Spill reading time= 389.438095 ms
