### PR TITLE
ISSUE #163 , Using only 2 legacy optimizer instead of all 

### DIFF
--- a/presto-main/src/main/java/io/prestosql/query/HetuLogicalPlanner.java
+++ b/presto-main/src/main/java/io/prestosql/query/HetuLogicalPlanner.java
@@ -14,6 +14,7 @@
  */
 package io.prestosql.query;
 
+import io.airlift.log.Logger;
 import io.prestosql.Session;
 import io.prestosql.cost.CachingCostProvider;
 import io.prestosql.cost.CachingStatsProvider;
@@ -31,6 +32,7 @@ import io.prestosql.sql.planner.LogicalPlanner;
 import io.prestosql.sql.planner.Plan;
 import io.prestosql.sql.planner.TypeAnalyzer;
 import io.prestosql.sql.planner.TypeProvider;
+import io.prestosql.sql.planner.iterative.IterativeOptimizer;
 import io.prestosql.sql.planner.optimizations.BeginTableWrite;
 import io.prestosql.sql.planner.optimizations.PlanOptimizer;
 import io.prestosql.sql.planner.sanity.PlanSanityChecker;
@@ -48,6 +50,7 @@ import static java.util.Objects.requireNonNull;
 public class HetuLogicalPlanner
         extends LogicalPlanner
 {
+    private static final Logger log = Logger.get(HetuLogicalPlanner.class);
     private final PlanNodeIdAllocator idAllocator;
 
     private final Session session;
@@ -104,6 +107,7 @@ public class HetuLogicalPlanner
                     if (OptimizerUtils.canApplyOptimizer(optimizer, optimizationLevel)) {
                         root = optimizer.optimize(root, session, planSymbolAllocator.getTypes(), planSymbolAllocator, idAllocator,
                                 warningCollector);
+                        log.debug("Rules called: %s", optimizer instanceof IterativeOptimizer ? ((IterativeOptimizer) optimizer).getRules() : optimizer.toString());
                         requireNonNull(root, format("%s returned a null plan", optimizer.getClass().getName()));
                         optimizationLevel = optimizationLevel == APPLY_ALL_RULES ? root.getSkipOptRuleLevel() : optimizationLevel;
                     }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/LogicalPlanner.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/LogicalPlanner.java
@@ -16,6 +16,7 @@ package io.prestosql.sql.planner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import io.airlift.log.Logger;
 import io.hetu.core.spi.cube.CubeFilter;
 import io.hetu.core.spi.cube.CubeMetadata;
 import io.hetu.core.spi.cube.CubeStatus;
@@ -64,6 +65,7 @@ import io.prestosql.sql.analyzer.RelationType;
 import io.prestosql.sql.analyzer.Scope;
 import io.prestosql.sql.parser.SqlParser;
 import io.prestosql.sql.planner.StatisticsAggregationPlanner.TableStatisticAggregation;
+import io.prestosql.sql.planner.iterative.IterativeOptimizer;
 import io.prestosql.sql.planner.optimizations.PlanOptimizer;
 import io.prestosql.sql.planner.plan.CubeFinishNode;
 import io.prestosql.sql.planner.plan.DeleteNode;
@@ -157,8 +159,8 @@ public class LogicalPlanner
         CREATED, OPTIMIZED, OPTIMIZED_AND_VALIDATED
     }
 
+    private static final Logger log = Logger.get(LogicalPlanner.class);
     private final PlanNodeIdAllocator idAllocator;
-
     private final Session session;
     private final List<PlanOptimizer> planOptimizers;
     private final PlanSanityChecker planSanityChecker;
@@ -225,6 +227,7 @@ public class LogicalPlanner
                 if (OptimizerUtils.isEnabledLegacy(optimizer, session, root) && OptimizerUtils.canApplyOptimizer(optimizer, optimizationLevel)) {
                     root = optimizer.optimize(root, session, planSymbolAllocator.getTypes(), planSymbolAllocator, idAllocator,
                             warningCollector);
+                    log.debug("Rules called: %s", optimizer instanceof IterativeOptimizer ? ((IterativeOptimizer) optimizer).getRules() : optimizer.toString());
                     requireNonNull(root, format("%s returned a null plan", optimizer.getClass().getName()));
                     optimizationLevel = optimizationLevel == APPLY_ALL_RULES ? root.getSkipOptRuleLevel() : optimizationLevel;
                 }

--- a/presto-main/src/main/java/io/prestosql/utils/OptimizerUtils.java
+++ b/presto-main/src/main/java/io/prestosql/utils/OptimizerUtils.java
@@ -35,6 +35,8 @@ import io.prestosql.sql.planner.iterative.rule.RowExpressionRewriteRuleSet;
 import io.prestosql.sql.planner.optimizations.ApplyConnectorOptimization;
 import io.prestosql.sql.planner.optimizations.LimitPushDown;
 import io.prestosql.sql.planner.optimizations.PlanOptimizer;
+import io.prestosql.sql.planner.optimizations.PruneUnreferencedOutputs;
+import io.prestosql.sql.planner.optimizations.StatsRecordingPlanOptimizer;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Arrays;
@@ -137,6 +139,9 @@ public class OptimizerUtils
             return true;
         }
 
+        if (!(optimizer instanceof IterativeOptimizer) && !(optimizer instanceof StatsRecordingPlanOptimizer) && !(optimizer instanceof PruneUnreferencedOutputs)) {
+            return false;
+        }
         // If it is IterativeOptimizer, then only rule as per level selected can be applied.
         return !(optimizer instanceof IterativeOptimizer)
                 || (((optimizationLevel != APPLY_ALL_LEGACY_AND_ROWEXPR


### PR DESCRIPTION

### What does this PR do / why do we need it:
Applies only two legacy optimizers to improve the performance

### Which issue(s) this PR fixes:

Fixes #
Applies only two legacy optimizers (StatsRecordingPlanOptimizer and PruneUnreferencedOutputs) instead of all which was the case by default.  #163

