### PR TITLE
[157] Spiller serialization optimizations

### DIFF
--- a/hetu-transport/src/main/java/io/hetu/core/transport/execution/buffer/GenericPagesSerde.java
+++ b/hetu-transport/src/main/java/io/hetu/core/transport/execution/buffer/GenericPagesSerde.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2018-2021. Huawei Technologies Co., Ltd. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.hetu.core.transport.execution.buffer;
+
+import io.prestosql.spi.Page;
+import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.StandardErrorCode;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public interface GenericPagesSerde
+{
+    default SerializedPage serialize(Page page)
+    {
+        throw new PrestoException(StandardErrorCode.NOT_FOUND, "Implementations for step serialization not found");
+    }
+
+    default Page deserialize(SerializedPage page)
+    {
+        throw new PrestoException(StandardErrorCode.NOT_FOUND, "Implementations for step deserialization not found");
+    }
+
+    /* interface to Serialize the page directly to the stream instead of creating serialized page and then writing it! */
+    default void serialize(OutputStream output, Page page)
+    {
+        throw new PrestoException(StandardErrorCode.NOT_FOUND, "Implementations for step serialization not found");
+    }
+
+    /* interface to read the page directly from the stream instead of creating serialized page and then deserialize it! */
+    default Page deserialize(InputStream input)
+    {
+        throw new PrestoException(StandardErrorCode.NOT_FOUND, "Implementations for step deserialization not found");
+    }
+}

--- a/hetu-transport/src/main/java/io/hetu/core/transport/execution/buffer/PagesSerde.java
+++ b/hetu-transport/src/main/java/io/hetu/core/transport/execution/buffer/PagesSerde.java
@@ -42,7 +42,7 @@ import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
 
 @NotThreadSafe
 public class PagesSerde
-        implements BlockEncodingSerdeProvider
+        implements BlockEncodingSerdeProvider, GenericPagesSerde
 {
     private static final double MINIMUM_COMPRESSION_RATIO = 0.8;
 

--- a/hetu-transport/src/main/java/io/hetu/core/transport/execution/buffer/PagesSerdeFactory.java
+++ b/hetu-transport/src/main/java/io/hetu/core/transport/execution/buffer/PagesSerdeFactory.java
@@ -35,16 +35,20 @@ public class PagesSerdeFactory
 
     public PagesSerde createPagesSerde()
     {
-        return createPagesSerdeInternal(Optional.empty());
+        return createPagesSerdeInternal(Optional.empty(), false);
     }
 
-    public PagesSerde createPagesSerdeForSpill(Optional<SpillCipher> spillCipher)
+    public PagesSerde createPagesSerdeForSpill(Optional<SpillCipher> spillCipher, boolean useDirectSerde)
     {
-        return createPagesSerdeInternal(spillCipher);
+        return createPagesSerdeInternal(spillCipher, useDirectSerde);
     }
 
-    private PagesSerde createPagesSerdeInternal(Optional<SpillCipher> spillCipher)
+    private PagesSerde createPagesSerdeInternal(Optional<SpillCipher> spillCipher, boolean useDirectSerde)
     {
+        if (useDirectSerde) {
+            return new SliceStreamPageSerde(blockEncodingSerde, Optional.empty(), Optional.empty(), spillCipher);
+        }
+
         if (compressionEnabled) {
             return new PagesSerde(blockEncodingSerde, Optional.of(new ZstdCompressor()), Optional.of(new ZstdDecompressor()), spillCipher);
         }

--- a/hetu-transport/src/main/java/io/hetu/core/transport/execution/buffer/SliceStreamPageSerde.java
+++ b/hetu-transport/src/main/java/io/hetu/core/transport/execution/buffer/SliceStreamPageSerde.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2018-2021. Huawei Technologies Co., Ltd. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.hetu.core.transport.execution.buffer;
+
+import io.airlift.compress.Compressor;
+import io.airlift.compress.Decompressor;
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.SliceOutput;
+import io.prestosql.spi.Page;
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.block.BlockEncodingSerde;
+import io.prestosql.spi.spiller.SpillCipher;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.util.Optional;
+import java.util.Properties;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class SliceStreamPageSerde
+        extends PagesSerde
+{
+    private final BlockEncodingSerde serde;
+
+    public SliceStreamPageSerde(BlockEncodingSerde blockEncodingSerde, Optional<Compressor> compressor, Optional<Decompressor> decompressor, Optional<SpillCipher> spillCipher)
+    {
+        super(blockEncodingSerde, compressor, decompressor, spillCipher);
+        this.serde = blockEncodingSerde;
+    }
+
+    @Override
+    public void serialize(OutputStream output, Page page)
+    {
+        checkArgument(output instanceof SliceOutput, "Page serializer does not support (" + output.getClass().getSimpleName() + ") for writing");
+        writePage((SliceOutput) output, page);
+    }
+
+    @Override
+    public Page deserialize(InputStream input)
+    {
+        checkArgument(input instanceof SliceInput, "Page serializer does not support (" + input.getClass().getSimpleName() + ") for reading");
+        return readPage((SliceInput) input);
+    }
+
+    private void writePage(SliceOutput output, Page page)
+    {
+        output.writeInt(page.getPositionCount());
+        output.writeInt(page.getChannelCount());
+        for (int channel = 0; channel < page.getChannelCount(); channel++) {
+            serde.writeBlock(output, page.getBlock(channel));
+        }
+
+        if (page.getPageMetadata().size() > 0) {
+            String pageProperties = page.getPageMetadata().toString();
+            byte[] propertiesByte = pageProperties
+                    .replaceAll(",", System.lineSeparator())
+                    .substring(1, pageProperties.length() - 1)
+                    .getBytes(UTF_8);
+            output.writeInt(propertiesByte.length);
+            output.writeBytes(propertiesByte);
+        }
+        else {
+            output.writeInt(0);
+        }
+    }
+
+    public Page readPage(SliceInput input)
+    {
+        int positionCount = input.readInt();
+        int numberOfBlocks = input.readInt();
+        Block[] blocks = new Block[numberOfBlocks];
+        for (int i = 0; i < blocks.length; i++) {
+            blocks[i] = serde.readBlock(input);
+        }
+
+        int propSize = input.readInt();
+        if (propSize > 0) {
+            byte[] pageMetadataBytes = new byte[propSize];
+            input.readBytes(pageMetadataBytes);
+            Properties pros = new Properties();
+            try {
+                pros.load(new ByteArrayInputStream(pageMetadataBytes));
+            }
+            catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+
+            return new Page(positionCount, pros, blocks);
+        }
+
+        return new Page(positionCount, blocks);
+    }
+}

--- a/presto-cli/src/main/java/io/prestosql/cli/StatusPrinter.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/StatusPrinter.java
@@ -206,9 +206,15 @@ Spilled: 20GB
             // Peak Memory: 1.97GB
             reprintLine("Peak Memory: " + FormatUtils.formatDataSize(bytes(stats.getPeakMemoryBytes()), true));
 
-            // Spilled Data: 20GB
+            // Spilled Data: 20GB, Writing Time: 22s, Reading Time: 1.2s
             if (stats.getSpilledBytes() > 0) {
-                reprintLine("Spilled: " + FormatUtils.formatDataSize(bytes(stats.getSpilledBytes()), true));
+                Duration readTime = millis(stats.getElapsedSpillReadTimeMillis());
+                Duration writeTime = millis(stats.getElapsedSpillWriteTimeMillis());
+                String summary = String.format("Spilled: %s, Writing Time: %.1fs, Reading Time: %.1fs",
+                        FormatUtils.formatDataSize(bytes(stats.getSpilledBytes()), true),
+                        writeTime.getValue(SECONDS),
+                        readTime.getValue(SECONDS));
+                reprintLine(summary);
             }
         }
 
@@ -302,9 +308,15 @@ Spilled: 20GB
                 // Peak Memory: 1.97GB
                 reprintLine("Peak Memory: " + FormatUtils.formatDataSize(bytes(stats.getPeakMemoryBytes()), true));
 
-                // Spilled Data: 20GB
+                // Spilled Data: 20GB, Writing Time: 25s, Reading Time: 8s
                 if (stats.getSpilledBytes() > 0) {
-                    reprintLine("Spilled: " + FormatUtils.formatDataSize(bytes(stats.getSpilledBytes()), true));
+                    Duration readTime = millis(stats.getElapsedSpillReadTimeMillis());
+                    Duration writeTime = millis(stats.getElapsedSpillWriteTimeMillis());
+                    String summary = String.format("Spilled: %s, Writing Time: %.1fs, Reading Time: %.1fs",
+                            FormatUtils.formatDataSize(bytes(stats.getSpilledBytes()), true),
+                            writeTime.getValue(SECONDS),
+                            readTime.getValue(SECONDS));
+                    reprintLine(summary);
                 }
             }
 

--- a/presto-client/src/main/java/io/prestosql/client/StatementStats.java
+++ b/presto-client/src/main/java/io/prestosql/client/StatementStats.java
@@ -44,6 +44,8 @@ public class StatementStats
     private final long processedBytes;
     private final long peakMemoryBytes;
     private final long spilledBytes;
+    private long elapsedSpillReadTimeMillis;
+    private long elapsedSpillWriteTimeMillis;
     private final StageStats rootStage;
 
     @JsonCreator
@@ -64,6 +66,8 @@ public class StatementStats
             @JsonProperty("processedBytes") long processedBytes,
             @JsonProperty("peakMemoryBytes") long peakMemoryBytes,
             @JsonProperty("spilledBytes") long spilledBytes,
+            @JsonProperty("elapsedSpillReadTimeMillis") long elapsedSpillReadTimeMillis,
+            @JsonProperty("elapsedSpillWriteTimeMillis") long elapsedSpillWriteTimeMillis,
             @JsonProperty("rootStage") StageStats rootStage)
     {
         this.state = requireNonNull(state, "state is null");
@@ -82,6 +86,8 @@ public class StatementStats
         this.processedBytes = processedBytes;
         this.peakMemoryBytes = peakMemoryBytes;
         this.spilledBytes = spilledBytes;
+        this.elapsedSpillReadTimeMillis = elapsedSpillReadTimeMillis;
+        this.elapsedSpillWriteTimeMillis = elapsedSpillWriteTimeMillis;
         this.rootStage = rootStage;
     }
 
@@ -197,6 +203,18 @@ public class StatementStats
         return spilledBytes;
     }
 
+    @JsonProperty
+    public long getElapsedSpillReadTimeMillis()
+    {
+        return elapsedSpillReadTimeMillis;
+    }
+
+    @JsonProperty
+    public long getElapsedSpillWriteTimeMillis()
+    {
+        return elapsedSpillWriteTimeMillis;
+    }
+
     @Override
     public String toString()
     {
@@ -217,6 +235,8 @@ public class StatementStats
                 .add("processedBytes", processedBytes)
                 .add("peakMemoryBytes", peakMemoryBytes)
                 .add("spilledBytes", spilledBytes)
+                .add("elapsedSpillReadTime", elapsedSpillReadTimeMillis)
+                .add("elapsedSpillWriteTime", elapsedSpillWriteTimeMillis)
                 .add("rootStage", rootStage)
                 .toString();
     }
@@ -245,6 +265,8 @@ public class StatementStats
         private long peakMemoryBytes;
         private long spilledBytes;
         private StageStats rootStage;
+        private long spillReadTimeMillis;
+        private long spillWriteTimeMillis;
 
         private Builder() {}
 
@@ -344,6 +366,18 @@ public class StatementStats
             return this;
         }
 
+        public Builder setSpilledWriteTimeMillis(long spillTime)
+        {
+            this.spillWriteTimeMillis = spillTime;
+            return this;
+        }
+
+        public Builder setSpilledReadTimeMillis(long spillTime)
+        {
+            this.spillReadTimeMillis = spillTime;
+            return this;
+        }
+
         public Builder setRootStage(StageStats rootStage)
         {
             this.rootStage = rootStage;
@@ -369,6 +403,8 @@ public class StatementStats
                     processedBytes,
                     peakMemoryBytes,
                     spilledBytes,
+                    spillReadTimeMillis,
+                    spillWriteTimeMillis,
                     rootStage);
         }
     }

--- a/presto-jdbc/src/test/java/io/prestosql/jdbc/TestProgressMonitor.java
+++ b/presto-jdbc/src/test/java/io/prestosql/jdbc/TestProgressMonitor.java
@@ -90,7 +90,7 @@ public class TestProgressMonitor
                 nextUriId == null ? null : server.url(format("/v1/statement/%s/%s", queryId, nextUriId)).uri(),
                 responseColumns,
                 data,
-                new StatementStats(state, state.equals("QUEUED"), true, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null),
+                new StatementStats(state, state.equals("QUEUED"), true, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null),
                 null,
                 ImmutableList.of(),
                 null,

--- a/presto-main/src/main/java/io/prestosql/execution/QueryStats.java
+++ b/presto-main/src/main/java/io/prestosql/execution/QueryStats.java
@@ -30,6 +30,7 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.OptionalDouble;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.units.DataSize.succinctBytes;
@@ -599,5 +600,23 @@ public class QueryStats
         return succinctBytes(operatorSummaries.stream()
                 .mapToLong(stats -> stats.getSpilledDataSize().toBytes())
                 .sum());
+    }
+
+    @JsonProperty
+    public Duration getSpilledReadTime()
+    {
+        return new Duration(operatorSummaries.stream()
+                    .mapToLong(stats -> stats.getSpillReadTime().toMillis())
+                    .sum(),
+                TimeUnit.MILLISECONDS).convertToMostSuccinctTimeUnit();
+    }
+
+    @JsonProperty
+    public Duration getSpilledWriteTime()
+    {
+        return new Duration(operatorSummaries.stream()
+                .mapToLong(stats -> stats.getSpillWriteTime().toMillis())
+                .sum(),
+                TimeUnit.MILLISECONDS).convertToMostSuccinctTimeUnit();
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/OperatorStats.java
+++ b/presto-main/src/main/java/io/prestosql/operator/OperatorStats.java
@@ -78,6 +78,8 @@ public class OperatorStats
     private final DataSize peakTotalMemoryReservation;
 
     private final DataSize spilledDataSize;
+    private final Duration spillReadTime;
+    private final Duration spillWriteTime;
 
     private final Optional<BlockedReason> blockedReason;
 
@@ -128,6 +130,8 @@ public class OperatorStats
             @JsonProperty("peakTotalMemoryReservation") DataSize peakTotalMemoryReservation,
 
             @JsonProperty("spilledDataSize") DataSize spilledDataSize,
+            @JsonProperty("spillReadTime") Duration spillReadTime,
+            @JsonProperty("spillWriteTime") Duration spillWriteTime,
 
             @JsonProperty("blockedReason") Optional<BlockedReason> blockedReason,
 
@@ -181,6 +185,8 @@ public class OperatorStats
         this.peakTotalMemoryReservation = requireNonNull(peakTotalMemoryReservation, "peakTotalMemoryReservation is null");
 
         this.spilledDataSize = requireNonNull(spilledDataSize, "spilledDataSize is null");
+        this.spillReadTime = requireNonNull(spillReadTime, "spillReadTime is null");
+        this.spillWriteTime = requireNonNull(spillWriteTime, "spillWriteTime is null");
 
         this.blockedReason = blockedReason;
 
@@ -398,6 +404,18 @@ public class OperatorStats
     }
 
     @JsonProperty
+    public Duration getSpillReadTime()
+    {
+        return spillReadTime;
+    }
+
+    @JsonProperty
+    public Duration getSpillWriteTime()
+    {
+        return spillWriteTime;
+    }
+
+    @JsonProperty
     public Optional<BlockedReason> getBlockedReason()
     {
         return blockedReason;
@@ -454,6 +472,8 @@ public class OperatorStats
         long peakTotalMemory = this.peakTotalMemoryReservation.toBytes();
 
         long spilledDataSize = this.spilledDataSize.toBytes();
+        long spillReadTime = this.spillReadTime.roundTo(NANOSECONDS);
+        long spillWriteTime = this.spillWriteTime.roundTo(NANOSECONDS);
 
         Optional<BlockedReason> blockedReason = this.blockedReason;
 
@@ -499,6 +519,8 @@ public class OperatorStats
             peakTotalMemory = max(peakTotalMemory, operator.getPeakTotalMemoryReservation().toBytes());
 
             spilledDataSize += operator.getSpilledDataSize().toBytes();
+            spillReadTime += operator.getSpillReadTime().roundTo(NANOSECONDS);
+            spillWriteTime += operator.getSpillWriteTime().roundTo(NANOSECONDS);
 
             if (operator.getBlockedReason().isPresent()) {
                 blockedReason = operator.getBlockedReason();
@@ -554,7 +576,8 @@ public class OperatorStats
                 succinctBytes(peakTotalMemory),
 
                 succinctBytes(spilledDataSize),
-
+                new Duration(spillReadTime, NANOSECONDS).convertToMostSuccinctTimeUnit(),
+                new Duration(spillWriteTime, NANOSECONDS).convertToMostSuccinctTimeUnit(),
                 blockedReason,
 
                 (OperatorInfo) base);
@@ -614,6 +637,8 @@ public class OperatorStats
                 peakRevocableMemoryReservation,
                 peakTotalMemoryReservation,
                 spilledDataSize,
+                spillReadTime,
+                spillWriteTime,
                 blockedReason,
                 (info != null && info.isFinal()) ? info : null);
     }

--- a/presto-main/src/main/java/io/prestosql/operator/SpillContext.java
+++ b/presto-main/src/main/java/io/prestosql/operator/SpillContext.java
@@ -23,6 +23,16 @@ public interface SpillContext
 {
     void updateBytes(long bytes);
 
+    default void updateWriteTime(long millis)
+    {
+        /* do nothing */
+    }
+
+    default void updateReadTime(long millis)
+    {
+        /* do nothing */
+    }
+
     default SpillContext newLocalSpillContext()
     {
         return new LocalSpillContext(this);

--- a/presto-main/src/main/java/io/prestosql/operator/WorkProcessorPipelineSourceOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/WorkProcessorPipelineSourceOperator.java
@@ -323,6 +323,7 @@ public class WorkProcessorPipelineSourceOperator
                         succinctBytes(context.peakRevocableMemoryReservation.get()),
                         succinctBytes(context.peakTotalMemoryReservation.get()),
                         new DataSize(0, BYTE),
+                        ZERO_DURATION, ZERO_DURATION,
                         operatorContext.isWaitingForMemory().isDone() ? Optional.empty() : Optional.of(WAITING_FOR_MEMORY),
                         null))
                 .collect(toImmutableList());

--- a/presto-main/src/main/java/io/prestosql/server/protocol/PagePublisherQueryManager.java
+++ b/presto-main/src/main/java/io/prestosql/server/protocol/PagePublisherQueryManager.java
@@ -62,7 +62,7 @@ public class PagePublisherQueryManager
     private final Set<String> queries = Sets.newConcurrentHashSet();
     private final Map<String, PagePublisherQueryRunner> queryRunners = new ConcurrentHashMap<>();
     private static final DataCenterQueryResults FINISHED_RESULTS_DONOT_USE_HEADER = new DataCenterQueryResults("", URI.create(""), null, null, null, null,
-            new StatementStats("FINISHED", false, false, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null), null,
+            new StatementStats("FINISHED", false, false, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null), null,
             Collections.emptyList(), null, false);
 
     private final DispatchManager dispatchManager;

--- a/presto-main/src/main/java/io/prestosql/server/protocol/PagePublisherQueryRunner.java
+++ b/presto-main/src/main/java/io/prestosql/server/protocol/PagePublisherQueryRunner.java
@@ -69,13 +69,13 @@ public class PagePublisherQueryRunner
     private static final Logger log = Logger.get(PagePublisherQueryRunner.class);
 
     private static final DataCenterQueryResults RUNNING_RESULTS = new DataCenterQueryResults("", URI.create(""), null, URI.create(""), null, null,
-            new StatementStats("RUNNING", false, false, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null), null,
+            new StatementStats("RUNNING", false, false, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null), null,
             Collections.emptyList(), null, true);
     private static final DataCenterQueryResults FINISHED_RESULTS = new DataCenterQueryResults("", URI.create(""), null, null, null, null,
-            new StatementStats("FINISHED", false, false, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null), null,
+            new StatementStats("FINISHED", false, false, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null), null,
             Collections.emptyList(), null, true);
     private static final DataCenterQueryResults FAILED_RESULTS = new DataCenterQueryResults("", URI.create(""), null, null, null, null,
-            new StatementStats("FAILED", false, false, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null), null,
+            new StatementStats("FAILED", false, false, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null), null,
             Collections.emptyList(), null, true);
     private static final Ordering<Comparable<Duration>> WAIT_ORDERING = Ordering.natural().nullsLast();
     private static final Duration MAX_WAIT_TIME = new Duration(1, SECONDS);

--- a/presto-main/src/main/java/io/prestosql/server/protocol/Query.java
+++ b/presto-main/src/main/java/io/prestosql/server/protocol/Query.java
@@ -831,6 +831,8 @@ public class Query
                 .setProcessedBytes(queryStats.getRawInputDataSize().toBytes())
                 .setPeakMemoryBytes(queryStats.getPeakUserMemoryReservation().toBytes())
                 .setSpilledBytes(queryStats.getSpilledDataSize().toBytes())
+                .setSpilledReadTimeMillis(queryStats.getSpilledReadTime().toMillis())
+                .setSpilledWriteTimeMillis(queryStats.getSpilledWriteTime().toMillis())
                 .setRootStage(toStageStats(outputStage))
                 .build();
     }

--- a/presto-main/src/main/java/io/prestosql/spiller/AesSpillCipher.java
+++ b/presto-main/src/main/java/io/prestosql/spiller/AesSpillCipher.java
@@ -92,6 +92,18 @@ final class AesSpillCipher
     }
 
     @Override
+    public Cipher getEncryptionCipher()
+    {
+        return createEncryptCipher(key);
+    }
+
+    @Override
+    public Cipher getDecryptionCipher(byte[] cipherIV)
+    {
+        return createDecryptCipher(key, new IvParameterSpec(cipherIV, 0, cipherIV.length));
+    }
+
+    @Override
     public void close()
     {
         /*
@@ -134,7 +146,12 @@ final class AesSpillCipher
     {
         Cipher cipher = createUninitializedCipher();
         try {
-            cipher.init(Cipher.DECRYPT_MODE, throwCipherClosedIfNull(key), iv);
+            if (iv == null) {
+                cipher.init(Cipher.DECRYPT_MODE, throwCipherClosedIfNull(key));
+            }
+            else {
+                cipher.init(Cipher.DECRYPT_MODE, throwCipherClosedIfNull(key), iv);
+            }
             return cipher;
         }
         catch (GeneralSecurityException e) {

--- a/presto-main/src/main/java/io/prestosql/spiller/NodeSpillConfig.java
+++ b/presto-main/src/main/java/io/prestosql/spiller/NodeSpillConfig.java
@@ -26,6 +26,8 @@ public class NodeSpillConfig
     private boolean spillCompressionEnabled;
     private boolean spillEncryptionEnabled;
 
+    private boolean spillDirectSerdeEnabled;
+
     @NotNull
     public DataSize getMaxSpillPerNode()
     {
@@ -73,6 +75,18 @@ public class NodeSpillConfig
     public NodeSpillConfig setSpillEncryptionEnabled(boolean spillEncryptionEnabled)
     {
         this.spillEncryptionEnabled = spillEncryptionEnabled;
+        return this;
+    }
+
+    public boolean isSpillDirectSerdeEnabled()
+    {
+        return spillDirectSerdeEnabled;
+    }
+
+    @Config("experimental.spill-direct-serde-enabled")
+    public NodeSpillConfig setSpillDirectSerdeEnabled(boolean spillDirectSerdeEnabled)
+    {
+        this.spillDirectSerdeEnabled = spillDirectSerdeEnabled;
         return this;
     }
 }

--- a/presto-main/src/test/java/io/prestosql/execution/TestQueryStats.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TestQueryStats.java
@@ -74,6 +74,8 @@ public class TestQueryStats
                     succinctBytes(129L),
                     succinctBytes(130L),
                     succinctBytes(131L),
+                    new Duration(133, NANOSECONDS),
+                    new Duration(134, NANOSECONDS),
                     Optional.empty(),
                     null),
             new OperatorStats(
@@ -112,6 +114,8 @@ public class TestQueryStats
                     succinctBytes(229L),
                     succinctBytes(230L),
                     succinctBytes(231L),
+                    new Duration(233, NANOSECONDS),
+                    new Duration(234, NANOSECONDS),
                     Optional.empty(),
                     null),
             new OperatorStats(
@@ -150,6 +154,8 @@ public class TestQueryStats
                     succinctBytes(329L),
                     succinctBytes(330L),
                     succinctBytes(331L),
+                    new Duration(333, NANOSECONDS),
+                    new Duration(334, NANOSECONDS),
                     Optional.empty(),
                     null));
 

--- a/presto-main/src/test/java/io/prestosql/operator/TestOperatorStats.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestOperatorStats.java
@@ -75,6 +75,8 @@ public class TestOperatorStats
             new DataSize(24, BYTE),
             new DataSize(25, BYTE),
             new DataSize(26, BYTE),
+            new Duration(27, NANOSECONDS),
+            new Duration(28, NANOSECONDS),
             Optional.empty(),
             NON_MERGEABLE_INFO);
 
@@ -121,6 +123,8 @@ public class TestOperatorStats
             new DataSize(24, BYTE),
             new DataSize(25, BYTE),
             new DataSize(26, BYTE),
+            new Duration(27, NANOSECONDS),
+            new Duration(28, NANOSECONDS),
             Optional.empty(),
             MERGEABLE_INFO);
 
@@ -176,6 +180,8 @@ public class TestOperatorStats
         assertEquals(actual.getPeakRevocableMemoryReservation(), new DataSize(24, BYTE));
         assertEquals(actual.getPeakTotalMemoryReservation(), new DataSize(25, BYTE));
         assertEquals(actual.getSpilledDataSize(), new DataSize(26, BYTE));
+        assertEquals(actual.getSpillReadTime(), new Duration(27, NANOSECONDS));
+        assertEquals(actual.getSpillWriteTime(), new Duration(28, NANOSECONDS));
         assertEquals(actual.getInfo().getClass(), SplitOperatorInfo.class);
         assertEquals(((SplitOperatorInfo) actual.getInfo()).getSplitInfo(), NON_MERGEABLE_INFO.getSplitInfo());
     }
@@ -223,6 +229,8 @@ public class TestOperatorStats
         assertEquals(actual.getPeakRevocableMemoryReservation(), new DataSize(24, BYTE));
         assertEquals(actual.getPeakTotalMemoryReservation(), new DataSize(25, BYTE));
         assertEquals(actual.getSpilledDataSize(), new DataSize(3 * 26, BYTE));
+        assertEquals(actual.getSpillReadTime(), new Duration(3 * 27, NANOSECONDS));
+        assertEquals(actual.getSpillWriteTime(), new Duration(3 * 28, NANOSECONDS));
         assertNull(actual.getInfo());
     }
 
@@ -269,6 +277,8 @@ public class TestOperatorStats
         assertEquals(actual.getPeakRevocableMemoryReservation(), new DataSize(24, BYTE));
         assertEquals(actual.getPeakTotalMemoryReservation(), new DataSize(25, BYTE));
         assertEquals(actual.getSpilledDataSize(), new DataSize(3 * 26, BYTE));
+        assertEquals(actual.getSpillReadTime(), new Duration(3 * 27, NANOSECONDS));
+        assertEquals(actual.getSpillWriteTime(), new Duration(3 * 28, NANOSECONDS));
         assertEquals(actual.getInfo().getClass(), PartitionedOutputInfo.class);
         assertEquals(((PartitionedOutputInfo) actual.getInfo()).getPagesAdded(), 3 * MERGEABLE_INFO.getPagesAdded());
     }

--- a/presto-main/src/test/java/io/prestosql/operator/TestOrderByOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestOrderByOperator.java
@@ -351,7 +351,7 @@ public class TestOrderByOperator
                 createTestMetadataManager().getFunctionAndTypeManager().getBlockEncodingSerde(),
                 new SpillerStats(),
                 ImmutableList.of(spillPath),
-                1.0, false, false);
+                1.0, false, false, false);
         return new GenericSpillerFactory(streamSpillerFactory);
     }
 

--- a/presto-main/src/test/java/io/prestosql/operator/TestWindowOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestWindowOperator.java
@@ -1171,7 +1171,7 @@ public class TestWindowOperator
                 createTestMetadataManager().getFunctionAndTypeManager().getBlockEncodingSerde(),
                 new SpillerStats(),
                 ImmutableList.of(spillPath),
-                1.0, false, false);
+                1.0, false, false, false);
         return new GenericSpillerFactory(streamSpillerFactory);
     }
 

--- a/presto-main/src/test/java/io/prestosql/spiller/TestFileSingleStreamSpiller.java
+++ b/presto-main/src/test/java/io/prestosql/spiller/TestFileSingleStreamSpiller.java
@@ -13,15 +13,18 @@
  */
 package io.prestosql.spiller;
 
+import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
 import com.google.common.util.concurrent.ListeningExecutorService;
+import io.airlift.log.Logger;
 import io.airlift.slice.InputStreamSliceInput;
 import io.hetu.core.transport.execution.buffer.PageCodecMarker;
 import io.hetu.core.transport.execution.buffer.PagesSerdeUtil;
 import io.hetu.core.transport.execution.buffer.SerializedPage;
 import io.prestosql.memory.context.LocalMemoryContext;
 import io.prestosql.operator.PageAssertions;
+import io.prestosql.operator.WorkProcessor;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.block.BlockBuilder;
 import io.prestosql.spi.type.Type;
@@ -31,13 +34,22 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.text.CharacterIterator;
+import java.text.StringCharacterIterator;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.MoreFiles.listFiles;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.prestosql.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.prestosql.metadata.MetadataManager.createTestMetadataManager;
 import static io.prestosql.spi.type.BigintType.BIGINT;
@@ -47,6 +59,7 @@ import static java.lang.Double.doubleToLongBits;
 import static java.nio.file.Files.createTempDirectory;
 import static java.nio.file.Files.newInputStream;
 import static java.util.concurrent.Executors.newCachedThreadPool;
+import static java.util.concurrent.Executors.newFixedThreadPool;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -54,8 +67,12 @@ import static org.testng.Assert.assertTrue;
 public class TestFileSingleStreamSpiller
 {
     private static final List<Type> TYPES = ImmutableList.of(BIGINT, DOUBLE, VARBINARY);
+    private static final List<Type> TYPES_BENCHMARK = ImmutableList.of(BIGINT);
+
+    private static final Logger log = Logger.get(TestFileSingleStreamSpiller.class);
 
     private final ListeningExecutorService executor = listeningDecorator(newCachedThreadPool());
+    private final ListeningExecutorService executorBenchmark = listeningDecorator(newFixedThreadPool(1, daemonThreadsNamed("binary-spiller-%s")));
     private final File spillPath = createTempDirectory(getClass().getName()).toFile();
 
     public TestFileSingleStreamSpiller()
@@ -67,6 +84,7 @@ public class TestFileSingleStreamSpiller
             throws Exception
     {
         executor.shutdown();
+        executorBenchmark.shutdown();
         deleteRecursively(spillPath.toPath(), ALLOW_INSECURE);
     }
 
@@ -108,7 +126,8 @@ public class TestFileSingleStreamSpiller
                 ImmutableList.of(spillPath.toPath()),
                 1.0,
                 compression,
-                encryption);
+                encryption,
+                false);
         LocalMemoryContext memoryContext = newSimpleAggregatedMemoryContext().newLocalMemoryContext("test");
         SingleStreamSpiller singleStreamSpiller = spillerFactory.create(TYPES, bytes -> {}, memoryContext);
         assertTrue(singleStreamSpiller instanceof FileSingleStreamSpiller);
@@ -161,5 +180,278 @@ public class TestFileSingleStreamSpiller
         col3.writeLong(doubleToLongBits(43.0)).writeLong(doubleToLongBits(43.0)).writeLong(doubleToLongBits(43.0)).writeLong(doubleToLongBits(43.0)).writeLong(doubleToLongBits(43.0)).writeLong(doubleToLongBits(43.0)).writeLong(1).closeEntry();
 
         return new Page(col1.build(), col2.build(), col3.build());
+    }
+
+    @Test
+    public void testSpillWithSingleFile()
+            throws Exception
+    {
+        assertSpillBenchmark(false, false, "1GB", 1, false);
+    }
+
+    @Test
+    public void testSpillWithMultiFile()
+            throws Exception
+    {
+        assertSpillBenchmark(false, false, "2MB", 500, false);
+    }
+
+    private void assertSpillBenchmark(boolean compression, boolean encryption, String pageSize, int fileCount, boolean useDirectSerde)
+            throws Exception
+    {
+        List<FileSingleStreamSpiller> spillers = new ArrayList<>();
+        FileSingleStreamSpillerFactory spillerFactory = new FileSingleStreamSpillerFactory(
+                executorBenchmark, // executor won't be closed, because we don't call destroy() on the spiller factory
+                createTestMetadataManager().getFunctionAndTypeManager().getBlockEncodingSerde(),
+                new SpillerStats(),
+                ImmutableList.of(spillPath.toPath()),
+                1.0,
+                compression,
+                encryption,
+                useDirectSerde);
+        LocalMemoryContext memoryContext = newSimpleAggregatedMemoryContext().newLocalMemoryContext("test");
+        long startTime = System.currentTimeMillis();
+        Stopwatch spillTimer = Stopwatch.createStarted();
+        long numberOfPages = pageSize.equals("1GB") ? 262144 : 512;
+        Page page = buildPageBenchmark();
+        for (int j = 1; j <= fileCount; j++) {
+            SingleStreamSpiller singleStreamSpiller = spillerFactory.create(TYPES, bytes -> {}, memoryContext);
+            assertTrue(singleStreamSpiller instanceof FileSingleStreamSpiller);
+            FileSingleStreamSpiller spiller = (FileSingleStreamSpiller) singleStreamSpiller;
+            spillers.add(spiller);
+
+            // The spillers will reserve memory in their constructors
+            assertEquals(memoryContext.getBytes(), 4096);
+            Iterator<Page> pageIterator = new Iterator<Page>()
+            {
+                private final long pageCount = numberOfPages;
+                private long counter = 1;
+
+                @Override
+                public boolean hasNext()
+                {
+                    return counter <= pageCount;
+                }
+
+                @Override
+                public Page next()
+                {
+                    if (counter > pageCount) {
+                        throw new RuntimeException();
+                    }
+                    counter++;
+                    return page;
+                }
+            };
+
+            spiller.spill(pageIterator).get();
+            assertEquals(listFiles(spillPath.toPath()).size(), j);
+        }
+        spillTimer.stop();
+        System.out.println("Time To Spill: " + spillTimer.elapsed(TimeUnit.MILLISECONDS) + " ms Traditional Timer: " + (System.currentTimeMillis() - startTime));
+        log.debug("TimeTakenToSpill = " + (System.currentTimeMillis() - startTime));
+
+        startTime = System.currentTimeMillis();
+        spillTimer.reset();
+        spillTimer.start();
+        for (int i = 0; i < fileCount; i++) {
+            Iterator<Page> spilledPagesIterator = spillers.get(i).getSpilledPages();
+            assertEquals(memoryContext.getBytes(), FileSingleStreamSpiller.BUFFER_SIZE);
+            spilledPagesIterator.forEachRemaining(page1 -> page1.getLoadedPage());
+        }
+        spillTimer.stop();
+        log.debug("TimeTakenReadingFromSpill = " + (System.currentTimeMillis() - startTime));
+        System.out.println("Time To Unspill: " + spillTimer.elapsed(TimeUnit.MILLISECONDS) + " ms, Traditional Timer: " + (System.currentTimeMillis() - startTime));
+        spillers.stream().forEach(spiller -> spiller.close());
+        assertEquals(listFiles(spillPath.toPath()).size(), 0);
+        assertEquals(memoryContext.getBytes(), 0);
+    }
+
+    private Page buildPageBenchmark()
+    {
+        BlockBuilder col1 = BIGINT.createBlockBuilder(null, 1);
+        BlockBuilder col2 = VARBINARY.createBlockBuilder(null, 1);
+
+        while (col1.getSizeInBytes() < 4 * 1024) {
+            col1.writeLong(42).writeLong(45).writeLong(45).writeLong(45).writeLong(45).writeLong(45);
+        }
+        col1.closeEntry();
+
+        while (col2.getSizeInBytes() < 4 * 1024) {
+            col2.writeLong(doubleToLongBits(43.0)).writeLong(doubleToLongBits(43.0)).writeLong(doubleToLongBits(43.0)).writeLong(doubleToLongBits(43.0)).writeLong(doubleToLongBits(43.0)).writeLong(doubleToLongBits(43.0)).writeLong(1);
+        }
+        col2.closeEntry();
+
+        return new Page(col1.build(), col2.build());
+    }
+
+    @Test
+    public void testSpillWithSingleSpillerConsolidatedWithCompression()
+            throws Exception
+    {
+        assertSpillBenchmarkReadingUsingWorkProcessor(true, false, "1GB", 1, false);
+        assertSpillBenchmarkReadingUsingWorkProcessor(true, false, "1GB", 1, true);
+    }
+
+    @Test
+    public void testSpillWithSingleSpillerConsolidatedWithCompressionMultiFile()
+            throws Exception
+    {
+        assertSpillBenchmarkReadingUsingWorkProcessor(true, false, "2MB", 512, false);
+        assertSpillBenchmarkReadingUsingWorkProcessor(true, false, "2MB", 512, true);
+    }
+
+    @Test
+    public void testSpillWithSingleSpillerConsolidatedWithoutCompression()
+            throws Exception
+    {
+        assertSpillBenchmarkReadingUsingWorkProcessor(false, false, "1GB", 1, false);
+        assertSpillBenchmarkReadingUsingWorkProcessor(false, false, "1GB", 1, true);
+    }
+
+    @Test
+    public void testSpillWithSingleSpillerConsolidatedWithoutCompressionMultiFile()
+            throws Exception
+    {
+        assertSpillBenchmarkReadingUsingWorkProcessor(false, false, "2MB", 512, false);
+        assertSpillBenchmarkReadingUsingWorkProcessor(false, false, "2MB", 512, true);
+    }
+
+    @Test
+    public void testSpillWithSingleSpillerConsolidatedWithEncryption()
+            throws Exception
+    {
+        assertSpillBenchmarkReadingUsingWorkProcessor(false, true, "1GB", 1, false);
+        assertSpillBenchmarkReadingUsingWorkProcessor(false, true, "1GB", 1, true);
+
+        assertSpillBenchmarkReadingUsingWorkProcessor(true, true, "1GB", 1, false);
+        assertSpillBenchmarkReadingUsingWorkProcessor(true, true, "1GB", 1, true);
+    }
+
+    private void assertSpillBenchmarkReadingUsingWorkProcessor(boolean compression, boolean encryption, String pageSize, int fileCount, boolean useDirectSerde)
+            throws Exception
+    {
+        List<FileSingleStreamSpiller> spillers = new ArrayList<>();
+        FileSingleStreamSpillerFactory spillerFactory = new FileSingleStreamSpillerFactory(
+                executorBenchmark, // executor won't be closed, because we don't call destroy() on the spiller factory
+                createTestMetadataManager().getFunctionAndTypeManager().getBlockEncodingSerde(),
+                new SpillerStats(),
+                ImmutableList.of(spillPath.toPath()),
+                1.0,
+                compression,
+                encryption,
+                useDirectSerde);
+
+        LocalMemoryContext memoryContext = newSimpleAggregatedMemoryContext().newLocalMemoryContext("test");
+        long startTime = System.currentTimeMillis();
+        Stopwatch spillTimer = Stopwatch.createStarted();
+        long numberOfPages = pageSize.equals("1GB") ? 262144 : 512;
+        Page page = buildPageBenchmark();
+        for (int j = 1; j <= fileCount; j++) {
+            SingleStreamSpiller singleStreamSpiller = spillerFactory.create(TYPES, bytes -> {}, memoryContext);
+            assertTrue(singleStreamSpiller instanceof FileSingleStreamSpiller);
+            FileSingleStreamSpiller spiller = (FileSingleStreamSpiller) singleStreamSpiller;
+            spillers.add(spiller);
+
+            // The spillers will reserve memory in their constructors
+            assertEquals(memoryContext.getBytes(), 4096);
+            Iterator<Page> pageIterator = new Iterator<Page>()
+            {
+                private final long pageCount = numberOfPages;
+                private long counter = 1;
+
+                @Override
+                public boolean hasNext()
+                {
+                    return counter <= pageCount;
+                }
+
+                @Override
+                public Page next()
+                {
+                    if (counter > pageCount) {
+                        throw new RuntimeException();
+                    }
+                    counter++;
+                    return page;
+                }
+            };
+
+            spiller.spill(pageIterator).get();
+            assertEquals(listFiles(spillPath.toPath()).size(), j);
+        }
+        spillTimer.stop();
+        long timeToSpill = spillTimer.elapsed(TimeUnit.MILLISECONDS);
+        log.debug("TimeTakenToSpill = " + (System.currentTimeMillis() - startTime));
+        long spilledDiskSize = getDirectorySize(spillPath.toPath());
+
+        startTime = System.currentTimeMillis();
+        spillTimer.reset();
+        spillTimer.start();
+        AtomicInteger pageCount = new AtomicInteger();
+        for (int i = 0; i < fileCount; i++) {
+            Iterator<Page> spilledPagesIterator = spillers.get(i).getSpilledPages();
+            WorkProcessor<Page> workProcessor = WorkProcessor.fromIterator(spilledPagesIterator);
+
+            workProcessor.iterator().forEachRemaining(page1 -> {
+                page1.getLoadedPage();
+                pageCount.getAndIncrement();
+            });
+            assertEquals(memoryContext.getBytes(), FileSingleStreamSpiller.BUFFER_SIZE);
+        }
+        spillTimer.stop();
+        long timeToUnspill = spillTimer.elapsed(TimeUnit.MILLISECONDS);
+        /*
+        * System.out.println(String.format("[isEncrypted: %6s, isCompressed: %6s, isDirect: %6s, SpillSize: %4s, SpillFiles: %4d] --> Spill: %8d, Unspill: %8d",
+        *      encryption, compression, useDirectSerde, pageSize, fileCount, timeToSpill, timeToUnspill, humanReadableByteCountBin(spilledDiskSize)));
+        */
+        log.debug("TimeTakenReadingFromSpill = " + (System.currentTimeMillis() - startTime));
+        log.info("[isEncrypted: %6s, isCompressed: %6s, isDirect: %6s, SpillSize: %4s, SpillFiles: %4d] --> Spill: %8d, Unspill: %8d, DiskUsed: %5s",
+                encryption, compression, useDirectSerde, pageSize, fileCount,
+                timeToSpill, timeToUnspill, humanReadableByteCountBin(spilledDiskSize));
+        spillers.stream().forEach(spiller -> spiller.close());
+        assertEquals(listFiles(spillPath.toPath()).size(), 0);
+        assertEquals(memoryContext.getBytes(), 0);
+    }
+
+    private static long getDirectorySize(Path path)
+    {
+        long size = 0;
+        try (Stream<Path> walk = Files.walk(path)) {
+            size = walk
+                    //.peek(System.out::println) // debug
+                    .filter(Files::isRegularFile)
+                    .mapToLong(p -> {
+                        // ugly, can pretty it with an extract method
+                        try {
+                            return Files.size(p);
+                        }
+                        catch (IOException e) {
+                            System.out.printf("Failed to get size of %s%n%s", p, e);
+                            return 0L;
+                        }
+                    })
+                    .sum();
+        }
+        catch (IOException e) {
+            System.out.printf("IO errors %s", e);
+        }
+        return size;
+    }
+
+    public static String humanReadableByteCountBin(long bytes)
+    {
+        long absB = bytes == Long.MIN_VALUE ? Long.MAX_VALUE : Math.abs(bytes);
+        if (absB < 1024) {
+            return bytes + " B";
+        }
+        long value = absB;
+        CharacterIterator ci = new StringCharacterIterator("KMGTPE");
+        for (int i = 40; i >= 0 && absB > 0xfffccccccccccccL >> i; i -= 10) {
+            value >>= 10;
+            ci.next();
+        }
+        value *= Long.signum(bytes);
+        return String.format("%.1f %ciB", value / 1024.0, ci.current());
     }
 }

--- a/presto-main/src/test/java/io/prestosql/spiller/TestFileSingleStreamSpillerFactory.java
+++ b/presto-main/src/test/java/io/prestosql/spiller/TestFileSingleStreamSpillerFactory.java
@@ -86,6 +86,7 @@ public class TestFileSingleStreamSpillerFactory
                 spillPaths,
                 1.0,
                 false,
+                false,
                 false);
 
         assertEquals(listFiles(spillPath1.toPath()).size(), 0);
@@ -125,6 +126,7 @@ public class TestFileSingleStreamSpillerFactory
                 spillPaths,
                 0.0,
                 false,
+                false,
                 false);
 
         spillerFactory.create(types, bytes -> {}, newSimpleAggregatedMemoryContext().newLocalMemoryContext("test"));
@@ -141,6 +143,7 @@ public class TestFileSingleStreamSpillerFactory
                 new SpillerStats(),
                 spillPaths,
                 1.0,
+                false,
                 false,
                 false);
         spillerFactory.create(types, bytes -> {}, newSimpleAggregatedMemoryContext().newLocalMemoryContext("test"));
@@ -170,6 +173,7 @@ public class TestFileSingleStreamSpillerFactory
                 new SpillerStats(),
                 spillPaths,
                 1.0,
+                false,
                 false,
                 false);
         spillerFactory.cleanupOldSpillFiles();

--- a/presto-main/src/test/java/io/prestosql/spiller/TestNodeSpillConfig.java
+++ b/presto-main/src/test/java/io/prestosql/spiller/TestNodeSpillConfig.java
@@ -34,7 +34,8 @@ public class TestNodeSpillConfig
                 .setMaxSpillPerNode(new DataSize(100, GIGABYTE))
                 .setQueryMaxSpillPerNode(new DataSize(100, GIGABYTE))
                 .setSpillCompressionEnabled(false)
-                .setSpillEncryptionEnabled(false));
+                .setSpillEncryptionEnabled(false)
+                .setSpillDirectSerdeEnabled(false));
     }
 
     @Test
@@ -45,13 +46,15 @@ public class TestNodeSpillConfig
                 .put("experimental.query-max-spill-per-node", "15 MB")
                 .put("experimental.spill-compression-enabled", "true")
                 .put("experimental.spill-encryption-enabled", "true")
+                .put("experimental.spill-direct-serde-enabled", "true")
                 .build();
 
         NodeSpillConfig expected = new NodeSpillConfig()
                 .setMaxSpillPerNode(new DataSize(10, MEGABYTE))
                 .setQueryMaxSpillPerNode(new DataSize(15, MEGABYTE))
                 .setSpillCompressionEnabled(true)
-                .setSpillEncryptionEnabled(true);
+                .setSpillEncryptionEnabled(true)
+                .setSpillDirectSerdeEnabled(true);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-main/src/test/java/io/prestosql/spiller/TestSpillCipherPagesSerde.java
+++ b/presto-main/src/test/java/io/prestosql/spiller/TestSpillCipherPagesSerde.java
@@ -41,7 +41,7 @@ public class TestSpillCipherPagesSerde
     public void test()
     {
         SpillCipher cipher = new AesSpillCipher();
-        PagesSerde serde = TESTING_SERDE_FACTORY.createPagesSerdeForSpill(Optional.of(cipher));
+        PagesSerde serde = TESTING_SERDE_FACTORY.createPagesSerdeForSpill(Optional.of(cipher), false);
         List<Type> types = ImmutableList.of(VARCHAR);
         Page emptyPage = new Page(VARCHAR.createBlockBuilder(null, 0).build());
         assertPageEquals(types, serde.deserialize(serde.serialize(emptyPage)), emptyPage);

--- a/presto-spi/src/main/java/io/prestosql/spi/spiller/SpillCipher.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/spiller/SpillCipher.java
@@ -13,6 +13,8 @@
  */
 package io.prestosql.spi.spiller;
 
+import javax.crypto.Cipher;
+
 public interface SpillCipher
         extends AutoCloseable
 {
@@ -39,6 +41,10 @@ public interface SpillCipher
      * @return The length of the decrypted content in destination buffer
      */
     int decrypt(byte[] encryptedData, int inputOffset, int length, byte[] destination, int destinationOffset);
+
+    Cipher getEncryptionCipher();
+
+    Cipher getDecryptionCipher(byte[] cipherIV);
 
     /**
      * Destroys the cipher, preventing future use. Implementations should allow this to be called multiple times


### PR DESCRIPTION
### What type of PR is this?
/kind feature

### What does this PR do / why do we need it:
* Single pass direct serialize / deserialize, instead of 2 pass (Page -> SerializedPage -> file/stream)
* Added Snappy Compressed writter
* Added configuration for direct serializer enable
* Added Spill/Unspill Timing stats capture and relayed to CLI

Performance test observation: [over TPCDS Q74]
|Sl No | Base(No Spill) | Base(With Spill) | with Direct  | Improvement  |
|---|---|---|---|---|
| Spill Write (s)  |  0 | 999.2  | 684  |  31.5% |
| Spill Read (s) |  0 |  256 |   151|   41.0%|
| Overall Spill (m) |  0 |  4.21 |  2.77 |  33.5% |
| QueryTime (m) |  5.89 |  25.58 |  20.19 |  19.6% |
| QueryTime Degrade(Ratio) |  0 |  4.3x |  3.3x |  1x |

### Which issue(s) this PR fixes:

Fixes #157 , #I4JUF0

### Special notes for your reviewers: