### PR TITLE
[#172] Fix: gramatical error in comment.

### DIFF
--- a/presto-main/src/main/java/io/prestosql/execution/executor/MultilevelSplitQueue.java
+++ b/presto-main/src/main/java/io/prestosql/execution/executor/MultilevelSplitQueue.java
@@ -154,7 +154,7 @@ public class MultilevelSplitQueue
      * Presto attempts to give each level a target amount of scheduled time, which is configurable
      * using levelTimeMultiplier.
      * <p>
-     * This function selects the level that has the the lowest ratio of actual to the target time
+     * This function selects the level that has the lowest ratio of actual to the target time
      * with the objective of minimizing deviation from the target scheduled time. From this level,
      * we pick the split with the lowest priority.
      */


### PR DESCRIPTION
### What type of PR is this?
Fix the gramatical error in comment.

Uncomment only one /kind <> line, hit enter to put that in a new line, and remove leading whitespaces from that line:

/kind bug /kind task /kind feature

### What does this PR do / why do we need it:

### Which issue(s) this PR fixes:

Fixes #172 

### Special notes for your reviewers: