### PR TITLE
[177]: Fix for spot bug in TestArbitraryOutputBuffer

### DIFF
--- a/presto-main/src/test/java/io/prestosql/execution/buffer/TestArbitraryOutputBuffer.java
+++ b/presto-main/src/test/java/io/prestosql/execution/buffer/TestArbitraryOutputBuffer.java
@@ -73,6 +73,7 @@ import static io.prestosql.testing.TestingTaskContext.createTaskContext;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -337,7 +338,8 @@ public class TestArbitraryOutputBuffer
         assertEquals(buffer.getInfo().getBuffers().stream().map(BufferInfo::getPagesSent).collect(Collectors.toList()), Arrays.asList(3L, 2L));
 
         // New buffer receives pending markers
-        outputBuffers.withBuffer(THIRD, BROADCAST_PARTITION_ID);
+        OutputBuffers outputBuffers1 = outputBuffers.withBuffer(THIRD, BROADCAST_PARTITION_ID);
+        assertNotNull(outputBuffers1);
         buffer.setOutputBuffers(outputBuffers);
         assertBufferResultEquals(TYPES, getBufferResult(buffer, THIRD, 0, sizeOfPages(3), NO_WAIT),
                 bufferResult(0, marker1, marker2));


### PR DESCRIPTION
### What type of PR is this?
fix the spot bugs
Uncomment only one /kind <> line, hit enter to put that in a new line, and remove leading whitespaces from that line:

/kind bug /kind task /kind feature

### What does this PR do / why do we need it:

### Which issue(s) this PR fixes:

Fixes #177 

### Special notes for your reviewers: