### PR TITLE
removed unused variables in TestHiveIntegrationSmokeTest

### DIFF
--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
@@ -1825,6 +1825,7 @@ public class TestHiveIntegrationSmokeTest
 
         // Hive will reorder the partition keys, so we must insert into the table assuming the partition keys have been moved to the end
         Long count = (Long) computeActual("SELECT count(*) from orders").getOnlyValue();
+        assertTrue(count >= 0, "return count should be 0 or more");
         assertUpdate(
                 session,
                 "" +


### PR DESCRIPTION
### What type of PR is this?

Uncomment only one /kind <> line, hit enter to put that in a new line, and remove leading whitespaces from that line:

/kind bug

### What does this PR do / why do we need it:

### Which issue(s) this PR fixes:

Fixes #203

### Special notes for your reviewers: