### PR TITLE
Fix write to static variable from instance method warning

### DIFF
--- a/presto-base-jdbc/src/test/java/io/prestosql/sql/builder/functioncall/TestFunctionWriterManagerGroup.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/sql/builder/functioncall/TestFunctionWriterManagerGroup.java
@@ -47,8 +47,7 @@ public class TestFunctionWriterManagerGroup
         DefaultUdfRewriteConfigSupplier defaultUdfRewriteConfigSupplier = new DefaultUdfRewriteConfigSupplier(Test_UDF_REWRITE_PATTERNS);
         DefaultConnectorConfigFunctionRewriter defaultConnectorConfigFunctionRewriter = new DefaultConnectorConfigFunctionRewriter(connectorName, defaultUdfRewriteConfigSupplier);
 
-        functionWriterManager1 = FunctionWriterManagerGroup.newFunctionWriterManagerInstance(connectorName,
-                versionName, functionCallRewriterMap, defaultConnectorConfigFunctionRewriter);
+        setFunctionWriterManager(connectorName, versionName, functionCallRewriterMap, defaultConnectorConfigFunctionRewriter);
 
         FunctionWriterManager functionWriterManager2 = FunctionWriterManagerGroup.newFunctionWriterManagerInstance(connectorName,
                 versionName, functionCallRewriterMap, defaultConnectorConfigFunctionRewriter);
@@ -108,5 +107,11 @@ public class TestFunctionWriterManagerGroup
         catch (UnsupportedOperationException exception) {
             assertEquals(exception.getMessage(), "jdbc_connector Connector does not support function call of LO10");
         }
+    }
+
+    private static void setFunctionWriterManager(String connectorName, String versionName, Map<String, FunctionCallRewriter> functionCallRewriterMap, DefaultConnectorConfigFunctionRewriter defaultConnectorConfigFunctionRewriter)
+    {
+        functionWriterManager1 = FunctionWriterManagerGroup.newFunctionWriterManagerInstance(connectorName,
+                versionName, functionCallRewriterMap, defaultConnectorConfigFunctionRewriter);
     }
 }


### PR DESCRIPTION
### What type of PR is this?

Uncomment only one /kind <> line, hit enter to put that in a new line, and remove leading whitespaces from that line:

/kind bug /kind task /kind feature

### What does this PR do / why do we need it:

### Which issue(s) this PR fixes:

Fixes #234 

### Special notes for your reviewers: