### PR TITLE
remove dead variables in MemoryTableProperties

### DIFF
--- a/presto-memory/src/main/java/io/prestosql/plugin/memory/MemoryTableProperties.java
+++ b/presto-memory/src/main/java/io/prestosql/plugin/memory/MemoryTableProperties.java
@@ -140,9 +140,6 @@ public class MemoryTableProperties
             name = name.substring(0, name.length() - 4).trim();
         }
         else if (lower.endsWith(" DESC")) {
-            name = name.substring(0, name.length() - 5).trim();
-            order = SortOrder.DESC_NULLS_LAST;
-
             // TODO: support DESC
             throw new UnsupportedOperationException("DESC sort is not supported yet.");
         }


### PR DESCRIPTION
### What type of PR is this?

Uncomment only one /kind <> line, hit enter to put that in a new line, and remove leading whitespaces from that line:

kind bug

### What does this PR do / why do we need it: Remove dead variables

### Which issue(s) this PR fixes:

Fixes #239 

### Special notes for your reviewers: