### PR TITLE
[258] Enable httpClient timeout configs for Exchange,Scheduler,MemMgr

### DIFF
--- a/hetu-docs/en/admin/properties.md
+++ b/hetu-docs/en/admin/properties.md
@@ -814,3 +814,25 @@ helps with cache affinity scheduling.
 > This property defines the maximum amount of time for the system to wait until all tasks are successfully restored. If any task is not ready within this timeout, then the recovery attempt is considered a failure, and the query will try to resume from an earlier snapshot if available.
 >
 > This can also be specified on a per-query basis using the `snapshot_retry_timeout` session property.
+
+## HTTP Client Configurations
+
+### `http.client.idle-timeout`
+
+> -   **Type:** `duration`
+> -   **Default value:** `30s` (30 seconds)
+>
+> This property defines the time for which a given http client shall stay connected without any operations performed over it.
+> After the specified time elapse with no activity, then the client connection is closed and related resources are released.
+>
+> (Note: this parameter should be configured with higher time when in high load environment)
+
+### `http.client.request-timeout`
+
+> -   **Type:** `duration`
+> -   **Default value:** `10s` (10 seconds)
+>
+> This property defines the time threshold for a given http client for which response should be received.
+> After the configured time elapsed and no response received, then client connection consider that to be failure in submission of request.
+>
+> (Note: this parameter should be configured with higher time when in high load environment)

--- a/presto-main/src/main/java/io/prestosql/server/ServerConfig.java
+++ b/presto-main/src/main/java/io/prestosql/server/ServerConfig.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class ServerConfig
 {
@@ -37,6 +38,8 @@ public class ServerConfig
     private boolean includeExceptionInResponse = true;
     private Duration gracePeriod = new Duration(2, MINUTES);
     private boolean enhancedErrorReporting = true;
+    private Duration httpClientIdleTimeout = new Duration(30, SECONDS);
+    private Duration httpClientRequestTimeout = new Duration(10, SECONDS);
     // Main coordinator TODO: remove this when main coordinator election is implemented
 
     private final Set<String> admins = new HashSet<>();
@@ -126,5 +129,31 @@ public class ServerConfig
     {
         this.enhancedErrorReporting = value;
         return this;
+    }
+
+    @Config("http.client.idle-timeout")
+    public ServerConfig setHttpClientIdleTimeout(Duration httpClientIdleTimeout)
+    {
+        this.httpClientIdleTimeout = httpClientIdleTimeout;
+        return this;
+    }
+
+    @MinDuration("30s")
+    public Duration getHttpClientIdleTimeout()
+    {
+        return httpClientIdleTimeout;
+    }
+
+    @Config("http.client.request-timeout")
+    public ServerConfig setHttpClientRequestTimeout(Duration httpClientRequestTimeout)
+    {
+        this.httpClientRequestTimeout = httpClientRequestTimeout;
+        return this;
+    }
+
+    @MinDuration("10s")
+    public Duration getHttpClientRequestTimeout()
+    {
+        return httpClientRequestTimeout;
     }
 }

--- a/presto-main/src/main/java/io/prestosql/server/ServerMainModule.java
+++ b/presto-main/src/main/java/io/prestosql/server/ServerMainModule.java
@@ -27,7 +27,6 @@ import io.airlift.stats.GcMonitor;
 import io.airlift.stats.JmxGcMonitor;
 import io.airlift.stats.PauseMeter;
 import io.airlift.units.DataSize;
-import io.airlift.units.Duration;
 import io.prestosql.GroupByHashPageIndexerFactory;
 import io.prestosql.PagesIndexPageSorter;
 import io.prestosql.SystemSessionProperties;
@@ -191,7 +190,6 @@ import static io.prestosql.protocol.SmileCodecBinder.smileCodecBinder;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.weakref.jmx.guice.ExportBinder.newExporter;
 
 public class ServerMainModule
@@ -309,8 +307,8 @@ public class ServerMainModule
         httpClientBinder(binder).bindHttpClient("node-manager", ForNodeManager.class)
                 .withTracing()
                 .withConfigDefaults(config -> {
-                    config.setIdleTimeout(new Duration(30, SECONDS));
-                    config.setRequestTimeout(new Duration(10, SECONDS));
+                    config.setIdleTimeout(serverConfig.getHttpClientIdleTimeout());
+                    config.setRequestTimeout(serverConfig.getHttpClientRequestTimeout());
                 });
 
         // node scheduler
@@ -393,8 +391,8 @@ public class ServerMainModule
                 .withTracing()
                 .withFilter(GenerateTraceTokenRequestFilter.class)
                 .withConfigDefaults(config -> {
-                    config.setIdleTimeout(new Duration(30, SECONDS));
-                    config.setRequestTimeout(new Duration(10, SECONDS));
+                    config.setIdleTimeout(serverConfig.getHttpClientIdleTimeout());
+                    config.setRequestTimeout(serverConfig.getHttpClientRequestTimeout());
                     config.setMaxConnectionsPerServer(250);
                     config.setMaxContentLength(new DataSize(32, MEGABYTE));
                 });

--- a/presto-main/src/test/java/io/prestosql/server/TestServerConfig.java
+++ b/presto-main/src/test/java/io/prestosql/server/TestServerConfig.java
@@ -22,7 +22,9 @@ import java.util.Map;
 
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class TestServerConfig
 {
@@ -35,7 +37,9 @@ public class TestServerConfig
                 .setPrestoVersion(null)
                 .setIncludeExceptionInResponse(true)
                 .setGracePeriod(new Duration(2, MINUTES))
-                .setEnhancedErrorReporting(true));
+                .setEnhancedErrorReporting(true)
+                .setHttpClientIdleTimeout(new Duration(30, SECONDS))
+                .setHttpClientRequestTimeout(new Duration(10, SECONDS)));
     }
 
     @Test
@@ -48,6 +52,8 @@ public class TestServerConfig
                 .put("http.include-exception-in-response", "false")
                 .put("shutdown.grace-period", "5m")
                 .put("sql.parser.enhanced-error-reporting", "false")
+                .put("http.client.idle-timeout", "5h")
+                .put("http.client.request-timeout", "30m")
                 .build();
 
         ServerConfig expected = new ServerConfig()
@@ -56,7 +62,9 @@ public class TestServerConfig
                 .setPrestoVersion("test")
                 .setIncludeExceptionInResponse(false)
                 .setGracePeriod(new Duration(5, MINUTES))
-                .setEnhancedErrorReporting(false);
+                .setEnhancedErrorReporting(false)
+                .setHttpClientIdleTimeout(new Duration(5, HOURS))
+                .setHttpClientRequestTimeout(new Duration(30, MINUTES));
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION

### What type of PR is this?
/kind feature

### What does this PR do / why do we need it:
Enable httpClient timeout configs for communicaton between CN and Workers.

### Which issue(s) this PR fixes:

Fixes #258 

### Special notes for your reviewers: