### PR TITLE
added Kryo Integration for Spiller Serialization

### DIFF
--- a/hetu-docs/en/admin/properties.md
+++ b/hetu-docs/en/admin/properties.md
@@ -254,6 +254,15 @@ This section describes the most important config properties that may be used to 
 >
 > Sets number of pages prefetched while reading from spilled files.
 
+
+### `experimental.spill-use-kryo-serialization`
+
+> -   **Type:** `boolean`
+> -   **Default value:** `false`
+>
+> Enables Kryo based serialization for spill to disk, instead of default java serializer.
+
+
 ### `experimental.revocable-memory-selection-threshold`
 
 > -   **Type:** `data size`

--- a/hetu-hbase/pom.xml
+++ b/hetu-hbase/pom.xml
@@ -17,7 +17,7 @@
         <version.annotations>13.0</version.annotations>
         <version.validation-api>2.0.1.Final</version.validation-api>
         <version.commons-lang3>3.10</version.commons-lang3>
-        <version.mockito-all>1.10.18</version.mockito-all>
+        <version.mockito-all>1.10.19</version.mockito-all>
         <version.testing>6.10</version.testing>
         <version.hbase>2.2.3</version.hbase>
         <version.jacoco-maven-plugin>0.8.2</version.jacoco-maven-plugin>
@@ -315,7 +315,7 @@
 
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <version>${version.mockito-all}</version>
             <scope>test</scope>
         </dependency>

--- a/hetu-heuristic-index/pom.xml
+++ b/hetu-heuristic-index/pom.xml
@@ -16,6 +16,7 @@
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <air.check.fail-duplicate-finder>false</air.check.fail-duplicate-finder>
         <org.slf4j.version>1.7.30</org.slf4j.version>
+        <powermock.version>2.0.2</powermock.version>
     </properties>
 
     <build>
@@ -100,36 +101,25 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.5.13</version>
+            <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-core</artifactId>
-            <version>2.0.2</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-testng</artifactId>
-            <version>2.0.2</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-testng-common</artifactId>
-            <version>2.0.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <version>2.0.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.objenesis</groupId>
-            <artifactId>objenesis</artifactId>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/hetu-metastore/pom.xml
+++ b/hetu-metastore/pom.xml
@@ -149,8 +149,8 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.18</version>
+            <artifactId>mockito-core</artifactId>
+            <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/hetu-transport/pom.xml
+++ b/hetu-transport/pom.xml
@@ -45,5 +45,10 @@
             <artifactId>jackson-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.esotericsoftware</groupId>
+            <artifactId>kryo</artifactId>
+            <version>5.0.3</version>
+        </dependency>
     </dependencies>
 </project>

--- a/hetu-transport/src/main/java/io/hetu/core/transport/block/BlockSerdeUtil.java
+++ b/hetu-transport/src/main/java/io/hetu/core/transport/block/BlockSerdeUtil.java
@@ -13,6 +13,10 @@
  */
 package io.hetu.core.transport.block;
 
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
@@ -41,8 +45,18 @@ public final class BlockSerdeUtil
         return blockEncodingSerde.readBlock(input);
     }
 
+    public static Block readBlock(Kryo kryo, Serializer blockEncodingSerde, Input input)
+    {
+        return (Block) blockEncodingSerde.read(kryo, input, null);
+    }
+
     public static void writeBlock(BlockEncodingSerde blockEncodingSerde, SliceOutput output, Block block)
     {
         blockEncodingSerde.writeBlock(output, block);
+    }
+
+    public static void writeBlock(Kryo kryo, Serializer blockEncodingSerde, Output output, Block block)
+    {
+        blockEncodingSerde.write(kryo, output, block);
     }
 }

--- a/hetu-transport/src/main/java/io/hetu/core/transport/execution/buffer/KryoPageSerializer.java
+++ b/hetu-transport/src/main/java/io/hetu/core/transport/execution/buffer/KryoPageSerializer.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2018-2022. Huawei Technologies Co., Ltd. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.hetu.core.transport.execution.buffer;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import io.prestosql.spi.Page;
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.block.BlockEncodingSerde;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.util.Optional;
+import java.util.Properties;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
+public class KryoPageSerializer
+        extends PagesSerde
+{
+    BlockEncodingSerde serde;
+    Serializer<Page> serializer = new Serializer<Page>()
+    {
+        @Override
+        public void write(Kryo kryo, Output output, Page page)
+        {
+            output.writeInt(page.getPositionCount());
+            output.writeInt(page.getChannelCount());
+            for (int channel = 0; channel < page.getChannelCount(); channel++) {
+                serde.writeBlock(output, page.getBlock(channel));
+            }
+
+            if (page.getPageMetadata().size() > 0) {
+                String pageProperties = page.getPageMetadata().toString();
+                byte[] propertiesByte = pageProperties
+                        .replaceAll(",", System.lineSeparator())
+                        .substring(1, pageProperties.length() - 1)
+                        .getBytes(UTF_8);
+                output.writeInt(propertiesByte.length);
+                output.writeBytes(propertiesByte);
+            }
+            else {
+                output.writeInt(0);
+            }
+        }
+
+        @Override
+        public Page read(Kryo kryo, Input input, Class<? extends Page> aClass)
+        {
+            int positionCount = input.readInt();
+            int numberOfBlocks = input.readInt();
+            Block[] blocks = new Block[numberOfBlocks];
+            for (int i = 0; i < blocks.length; i++) {
+                blocks[i] = serde.readBlock(input);
+            }
+
+            int propSize = input.readInt();
+            if (propSize > 0) {
+                byte[] pageMetadataBytes = input.readBytes(propSize);
+                Properties pros = new Properties();
+                try {
+                    pros.load(new ByteArrayInputStream(pageMetadataBytes));
+                }
+                catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+
+                return new Page(positionCount, pros, blocks);
+            }
+
+            return new Page(positionCount, blocks);
+        }
+    };
+
+    KryoPageSerializer(BlockEncodingSerde serde)
+    {
+        super(serde, Optional.empty(), Optional.empty(), Optional.empty());
+        this.serde = requireNonNull(serde, "Serde Cannot be null");
+    }
+
+    @Override
+    public void serialize(OutputStream output, Page page)
+    {
+        checkArgument(output instanceof Output, "Page serializer does not support (" + output.getClass().getSimpleName() + ") for writing");
+        serializer.write(null, (Output) output, page);
+    }
+
+    @Override
+    public Page deserialize(InputStream input)
+    {
+        checkArgument(input instanceof Input, "Page serializer does not support (" + input.getClass().getSimpleName() + ") for reading");
+        return serializer.read(null, (Input) input, Page.class);
+    }
+}

--- a/hetu-transport/src/main/java/io/hetu/core/transport/execution/buffer/PagesSerdeFactory.java
+++ b/hetu-transport/src/main/java/io/hetu/core/transport/execution/buffer/PagesSerdeFactory.java
@@ -35,17 +35,21 @@ public class PagesSerdeFactory
 
     public PagesSerde createPagesSerde()
     {
-        return createPagesSerdeInternal(Optional.empty(), false);
+        return createPagesSerdeInternal(Optional.empty(), false, false);
     }
 
-    public PagesSerde createPagesSerdeForSpill(Optional<SpillCipher> spillCipher, boolean useDirectSerde)
+    public PagesSerde createPagesSerdeForSpill(Optional<SpillCipher> spillCipher, boolean useDirectSerde, boolean useKryo)
     {
-        return createPagesSerdeInternal(spillCipher, useDirectSerde);
+        return createPagesSerdeInternal(spillCipher, useDirectSerde, useKryo);
     }
 
-    private PagesSerde createPagesSerdeInternal(Optional<SpillCipher> spillCipher, boolean useDirectSerde)
+    private PagesSerde createPagesSerdeInternal(Optional<SpillCipher> spillCipher, boolean useDirectSerde, boolean useKryo)
     {
         if (useDirectSerde) {
+            if (useKryo) {
+                return new KryoPageSerializer(blockEncodingSerde);
+            }
+
             return new SliceStreamPageSerde(blockEncodingSerde, Optional.empty(), Optional.empty(), spillCipher);
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -1491,7 +1491,7 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>1.9.5</version>
+                <version>1.10.19</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -305,8 +305,21 @@
 
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
             <version>1.10.19</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.objenesis</groupId>
+                    <artifactId>objenesis</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>1.1</version>
             <scope>test</scope>
         </dependency>
 
@@ -423,6 +436,12 @@
             <artifactId>bcprov-jdk15on</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.esotericsoftware</groupId>
+            <artifactId>kryo</artifactId>
+            <version>5.0.3</version>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>org.testng</groupId>
@@ -466,6 +485,12 @@
             <artifactId>presto-spi</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.esotericsoftware</groupId>
+                    <artifactId>kryo</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/presto-main/src/main/java/io/prestosql/metadata/InternalBlockEncodingSerde.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/InternalBlockEncodingSerde.java
@@ -75,7 +75,7 @@ final class InternalBlockEncodingSerde
         }
     }
 
-    private static String readLengthPrefixedString(SliceInput input)
+    protected static String readLengthPrefixedString(SliceInput input)
     {
         int length = input.readInt();
         byte[] bytes = new byte[length];

--- a/presto-main/src/main/java/io/prestosql/metadata/KryoBlockEncodingSerde.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/KryoBlockEncodingSerde.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2018-2022. Huawei Technologies Co., Ltd. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.metadata;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.StandardErrorCode;
+import io.prestosql.spi.block.AbstractBlockEncoding;
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.block.BlockEncoding;
+import io.prestosql.spi.block.BlockEncodingSerde;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
+public class KryoBlockEncodingSerde
+        implements BlockEncodingSerde
+{
+    private final FunctionAndTypeManager functionAndTypeManager;
+    private final Kryo kryo;
+
+    public KryoBlockEncodingSerde(FunctionAndTypeManager metadata, Kryo kryo)
+    {
+        this.functionAndTypeManager = requireNonNull(metadata, "metadata is null");
+        this.kryo = kryo; /*Todo(nitin) make it singleton inject time initializer */
+    }
+
+    public Kryo getKryo()
+    {
+        return kryo;
+    }
+
+    @Override
+    public Object getContext()
+    {
+        return getKryo();
+    }
+
+    /**
+     * Read a block encoding from the input.
+     *
+     * @param inputStream
+     */
+    @Override
+    public Block readBlock(InputStream inputStream)
+    {
+        if (!(inputStream instanceof Input)) {
+            throw new PrestoException(StandardErrorCode.GENERIC_INTERNAL_ERROR,
+                    "This interface should not be called in this flow");
+        }
+
+        Input input = (Input) inputStream;
+        String encodingName;
+        // read the encoding name
+        encodingName = readLengthPrefixedString((Input) input);
+
+        // look up the encoding factory
+        BlockEncoding blockEncoding = functionAndTypeManager.getBlockEncoding(encodingName);
+        Serializer<?> serializer = getSerializerFromBlockEncoding(blockEncoding);
+        if (serializer == null) {
+            return (Block) blockEncoding.readBlock(this, inputStream);
+        }
+        return (Block) serializer.read(kryo, input, null);
+    }
+
+    /**
+     * Write a blockEncoding to the output.
+     *
+     * @param outputStream
+     * @param block
+     */
+    @Override
+    public void writeBlock(OutputStream outputStream, Block block)
+    {
+        if (!(outputStream instanceof Output)) {
+            throw new PrestoException(StandardErrorCode.GENERIC_INTERNAL_ERROR,
+                    "This interface should not be called in this flow");
+        }
+
+        Output output = (Output) outputStream;
+
+        String encodingName = block.getEncodingName();
+        BlockEncoding blockEncoding = functionAndTypeManager.getBlockEncoding(encodingName);
+        Serializer<Block<?>> serializer = getSerializerFromBlockEncoding(blockEncoding);
+
+        // write the name to the output
+        writeLengthPrefixedString(output, encodingName);
+
+        if (serializer == null) {
+            blockEncoding.writeBlock(this, outputStream, block);
+        }
+        else {
+            // write the block to the output
+            serializer.write(kryo, output, block);
+        }
+    }
+
+    private Serializer<Block<?>> getSerializerFromBlockEncoding(BlockEncoding blockEncoding)
+    {
+        if (blockEncoding instanceof AbstractBlockEncoding) {
+            return (Serializer<Block<?>>) blockEncoding;
+        }
+        return null;
+    }
+
+    private static String readLengthPrefixedString(Input input)
+    {
+        int length = input.readInt();
+        byte[] bytes = input.readBytes(length);
+        return new String(bytes, UTF_8);
+    }
+
+    private static void writeLengthPrefixedString(Output output, String value)
+    {
+        byte[] bytes = value.getBytes(UTF_8);
+        output.writeInt(bytes.length);
+        output.writeBytes(bytes);
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/MetadataManager.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.metadata;
 
+import com.esotericsoftware.kryo.Kryo;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.collect.HashMultimap;
@@ -201,7 +202,7 @@ public final class MetadataManager
     public static MetadataManager createTestMetadataManager(TransactionManager transactionManager, FeaturesConfig featuresConfig)
     {
         return new MetadataManager(
-                new FunctionAndTypeManager(transactionManager, featuresConfig, new HandleResolver(), ImmutableSet.of()),
+                new FunctionAndTypeManager(transactionManager, featuresConfig, new HandleResolver(), ImmutableSet.of(), new Kryo()),
                 featuresConfig,
                 new SessionPropertyManager(),
                 new SchemaPropertyManager(),

--- a/presto-main/src/main/java/io/prestosql/server/ServerMainModule.java
+++ b/presto-main/src/main/java/io/prestosql/server/ServerMainModule.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.server;
 
+import com.esotericsoftware.kryo.Kryo;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
 import com.google.inject.Key;
@@ -438,6 +439,8 @@ public class ServerMainModule
         binder.bind(TypeAnalyzer.class).in(Scopes.SINGLETON);
         jsonBinder(binder).addDeserializerBinding(Type.class).to(TypeDeserializer.class);
         newSetBinder(binder, Type.class);
+
+        binder.bind(Kryo.class).in(Scopes.SINGLETON);
 
         // split manager
         binder.bind(SplitManager.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/io/prestosql/spiller/NodeSpillConfig.java
+++ b/presto-main/src/main/java/io/prestosql/spiller/NodeSpillConfig.java
@@ -31,6 +31,7 @@ public class NodeSpillConfig
     private boolean spillDirectSerdeEnabled;
 
     private int spillPrefetchReadPages = 1;
+    private boolean spillUseKryoSerialization;
 
     @NotNull
     public DataSize getMaxSpillPerNode()
@@ -105,6 +106,18 @@ public class NodeSpillConfig
     public NodeSpillConfig setSpillPrefetchReadPages(int spillPrefetchedReadPages)
     {
         this.spillPrefetchReadPages = spillPrefetchedReadPages;
+        return this;
+    }
+
+    public boolean isSpillUseKryoSerialization()
+    {
+        return spillUseKryoSerialization;
+    }
+
+    @Config("experimental.spill-use-kryo-serialization")
+    public NodeSpillConfig setSpillUseKryoSerialization(boolean spillUseKryoSerialization)
+    {
+        this.spillUseKryoSerialization = spillUseKryoSerialization;
         return this;
     }
 }

--- a/presto-main/src/main/java/io/prestosql/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/io/prestosql/testing/LocalQueryRunner.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.testing;
 
+import com.esotericsoftware.kryo.Kryo;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -340,7 +341,7 @@ public class LocalQueryRunner
         this.planOptimizerManager = new ConnectorPlanOptimizerManager();
 
         this.metadata = new MetadataManager(
-                new FunctionAndTypeManager(transactionManager, featuresConfig, new HandleResolver(), ImmutableSet.of()),
+                new FunctionAndTypeManager(transactionManager, featuresConfig, new HandleResolver(), ImmutableSet.of(), new Kryo()),
                 featuresConfig,
                 // new HetuConfig object passed, if split filtering is needed in the runner, a modified HetuConfig object with filter settings manually set must be used.
                 new SessionPropertyManager(new SystemSessionProperties(new QueryManagerConfig(), taskManagerConfig, new MemoryManagerConfig(), featuresConfig, new HetuConfig(), new SnapshotConfig())),

--- a/presto-main/src/test/java/io/prestosql/operator/TestGroupByHash.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestGroupByHash.java
@@ -331,7 +331,7 @@ public class TestGroupByHash
         expectedMapping.put("hashCollisions", 37L);
         expectedMapping.put("expectedHashCollisions", 0.0);
         expectedMapping.put("preallocatedMemoryInBytes", 0L);
-        expectedMapping.put("currentPageSizeInBytes", 4732L);
+        expectedMapping.put("currentPageSizeInBytes", 4740L);
 
         return expectedMapping;
     }

--- a/presto-main/src/test/java/io/prestosql/operator/TestHashAggregationOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestHashAggregationOperator.java
@@ -317,7 +317,7 @@ public class TestHashAggregationOperator
         //TODO-cp-I2DSGQ: change expectedMapping after implementation of operatorContext capture
         expectedMapping.put("operatorContext", 0);
         expectedMapping.put("aggregationBuilder", aggregationBuilderMapping);
-        expectedMapping.put("memoryContext", 10355419L);
+        expectedMapping.put("memoryContext", 10675419L);
         expectedMapping.put("inputProcessed", true);
         expectedMapping.put("finishing", false);
         expectedMapping.put("finished", false);
@@ -405,7 +405,7 @@ public class TestHashAggregationOperator
         aggregation3Array0.put("capacity", 40960);
         aggregation3Array0.put("segments", 40);
         aggregation3Array1.put("array", blockObjectBigArrayState);
-        aggregation3Array1.put("sizeOfBlocks", 2504108L);
+        aggregation3Array1.put("sizeOfBlocks", 2824108L);
         blockObjectBigArrayState.put("array", 1);
         blockObjectBigArrayState.put("capacity", 40960);
         aggregation3StateList.add(39999L);

--- a/presto-main/src/test/java/io/prestosql/operator/TestOrderByOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestOrderByOperator.java
@@ -266,7 +266,7 @@ public class TestOrderByOperator
         Map<String, Object> expectedMapping = new HashMap<>();
         expectedMapping.put("operatorContext", 0);
         expectedMapping.put("revocableMemoryContext", 0L);
-        expectedMapping.put("localUserMemoryContext", 8828L);
+        expectedMapping.put("localUserMemoryContext", 8844L);
         return expectedMapping;
     }
 

--- a/presto-main/src/test/java/io/prestosql/operator/TestPagesIndex.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestPagesIndex.java
@@ -80,8 +80,8 @@ public class TestPagesIndex
         expectedMapping.put("valueAddresses", valueAddresses);
         expectedMapping.put("nextBlockToCompact", 0);
         expectedMapping.put("positionCount", 7);
-        expectedMapping.put("pagesMemorySize", 3852L);
-        expectedMapping.put("estimatedSize", 12396L);
+        expectedMapping.put("pagesMemorySize", 3860L);
+        expectedMapping.put("estimatedSize", 12404L);
         return expectedMapping;
     }
 

--- a/presto-main/src/test/java/io/prestosql/operator/TestStreamingAggregationOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestStreamingAggregationOperator.java
@@ -178,7 +178,7 @@ public class TestStreamingAggregationOperator
         Map<String, Object> expectedMapping = new HashMap<>();
         expectedMapping.put("operatorContext", 0);
         expectedMapping.put("systemMemoryContext", 0L);
-        expectedMapping.put("userMemoryContext", 2236L);
+        expectedMapping.put("userMemoryContext", 2244L);
         expectedMapping.put("finishing", false);
         return expectedMapping;
     }

--- a/presto-main/src/test/java/io/prestosql/operator/TestTopNOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestTopNOperator.java
@@ -179,7 +179,7 @@ public class TestTopNOperator
         expectedMapping.put("operatorContext", 0);
         expectedMapping.put("workProcessorOperator", workProcessorOperatorMapping);
 
-        workProcessorOperatorMapping.put("localUserMemoryContext", 19152L);
+        workProcessorOperatorMapping.put("localUserMemoryContext", 19168L);
         workProcessorOperatorMapping.put("topNBuilder", topNBuilderMapping);
         workProcessorOperatorMapping.put("outputIterator", false);
 
@@ -187,7 +187,7 @@ public class TestTopNOperator
         topNBuilderMapping.put("groupedRows", groupedRowsMapping);
         topNBuilderMapping.put("pageReferences", pageReferencesMapping);
         topNBuilderMapping.put("emptyPageReferenceSlots", emptyPageReferenceSlots);
-        topNBuilderMapping.put("memorySizeInBytes", 2496L);
+        topNBuilderMapping.put("memorySizeInBytes", 2512L);
         topNBuilderMapping.put("currentPageCount", 2);
 
         groupedRowsMapping.put("array", Object[][].class);

--- a/presto-main/src/test/java/io/prestosql/spiller/TestNodeSpillConfig.java
+++ b/presto-main/src/test/java/io/prestosql/spiller/TestNodeSpillConfig.java
@@ -36,7 +36,8 @@ public class TestNodeSpillConfig
                 .setSpillCompressionEnabled(false)
                 .setSpillEncryptionEnabled(false)
                 .setSpillDirectSerdeEnabled(false)
-                .setSpillPrefetchReadPages(1));
+                .setSpillPrefetchReadPages(1)
+                .setSpillUseKryoSerialization(false));
     }
 
     @Test
@@ -49,6 +50,7 @@ public class TestNodeSpillConfig
                 .put("experimental.spill-encryption-enabled", "true")
                 .put("experimental.spill-direct-serde-enabled", "true")
                 .put("experimental.spill-prefetch-read-pages", "25")
+                .put("experimental.spill-use-kryo-serialization", "true")
                 .build();
 
         NodeSpillConfig expected = new NodeSpillConfig()
@@ -57,7 +59,8 @@ public class TestNodeSpillConfig
                 .setSpillCompressionEnabled(true)
                 .setSpillEncryptionEnabled(true)
                 .setSpillDirectSerdeEnabled(true)
-                .setSpillPrefetchReadPages(25);
+                .setSpillPrefetchReadPages(25)
+                .setSpillUseKryoSerialization(true);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-main/src/test/java/io/prestosql/spiller/TestSpillCipherPagesSerde.java
+++ b/presto-main/src/test/java/io/prestosql/spiller/TestSpillCipherPagesSerde.java
@@ -41,7 +41,7 @@ public class TestSpillCipherPagesSerde
     public void test()
     {
         SpillCipher cipher = new AesSpillCipher();
-        PagesSerde serde = TESTING_SERDE_FACTORY.createPagesSerdeForSpill(Optional.of(cipher), false);
+        PagesSerde serde = TESTING_SERDE_FACTORY.createPagesSerdeForSpill(Optional.of(cipher), false, false);
         List<Type> types = ImmutableList.of(VARCHAR);
         Page emptyPage = new Page(VARCHAR.createBlockBuilder(null, 0).build());
         assertPageEquals(types, serde.deserialize(serde.serialize(emptyPage)), emptyPage);

--- a/presto-spi/pom.xml
+++ b/presto-spi/pom.xml
@@ -145,5 +145,10 @@
             <groupId>io.airlift</groupId>
             <artifactId>joni</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.esotericsoftware</groupId>
+            <artifactId>kryo</artifactId>
+            <version>5.0.3</version>
+        </dependency>
     </dependencies>
 </project>

--- a/presto-spi/src/main/java/io/prestosql/spi/block/AbstractBlockEncoding.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/block/AbstractBlockEncoding.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2018-2022. Huawei Technologies Co., Ltd. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.spi.block;
+
+import com.esotericsoftware.kryo.Serializer;
+
+public abstract class AbstractBlockEncoding<T>
+        extends Serializer<T>
+        implements BlockEncoding
+{
+}

--- a/presto-spi/src/main/java/io/prestosql/spi/block/BlockEncoding.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/block/BlockEncoding.java
@@ -16,6 +16,8 @@ package io.prestosql.spi.block;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
 
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.Optional;
 
 public interface BlockEncoding
@@ -35,6 +37,17 @@ public interface BlockEncoding
      * Write the specified block to the specified output
      */
     void writeBlock(BlockEncodingSerde blockEncodingSerde, SliceOutput sliceOutput, Block block);
+
+    /**
+     * Read a block from the specified input.  The returned
+     * block should begin at the specified position.
+     */
+    Block readBlock(BlockEncodingSerde blockEncodingSerde, InputStream input);
+
+    /**
+     * Write the specified block to the specified output
+     */
+    void writeBlock(BlockEncodingSerde blockEncodingSerde, OutputStream output, Block block);
 
     /**
      * This method allows the implementor to specify a replacement object that will be serialized instead of the original one.

--- a/presto-spi/src/main/java/io/prestosql/spi/block/BlockEncodingSerde.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/block/BlockEncodingSerde.java
@@ -15,16 +15,49 @@ package io.prestosql.spi.block;
 
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
+import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.StandardErrorCode;
+
+import java.io.InputStream;
+import java.io.OutputStream;
 
 public interface BlockEncodingSerde
 {
     /**
      * Read a block encoding from the input.
      */
-    Block readBlock(SliceInput input);
+    default Block readBlock(InputStream input)
+    {
+        throw new PrestoException(StandardErrorCode.NOT_SUPPORTED, "Not supported");
+    }
 
     /**
      * Write a blockEncoding to the output.
      */
-    void writeBlock(SliceOutput output, Block block);
+    default void writeBlock(OutputStream output, Block block)
+    {
+        throw new PrestoException(StandardErrorCode.NOT_SUPPORTED, "Not supported");
+    }
+
+    /**
+     * Read a block encoding from the input.
+     */
+    default Block readBlock(SliceInput input)
+    {
+        throw new PrestoException(StandardErrorCode.NOT_SUPPORTED, "Not supported");
+    }
+
+    /**
+     * Write a blockEncoding to the output.
+     */
+    default void writeBlock(SliceOutput output, Block block)
+    {
+        throw new PrestoException(StandardErrorCode.NOT_SUPPORTED, "Not supported");
+    }
+
+    /* give out context object if any */
+    default Object getContext()
+    {
+        return null;
+    }
 }

--- a/presto-spi/src/main/java/io/prestosql/spi/block/ByteArrayBlock.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/block/ByteArrayBlock.java
@@ -35,11 +35,11 @@ public class ByteArrayBlock
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(ByteArrayBlock.class).instanceSize();
 
-    private final int arrayOffset;
+    protected final int arrayOffset;
     private final int positionCount;
     @Nullable
-    private final boolean[] valueIsNull;
-    private final byte[] values;
+    protected final boolean[] valueIsNull;
+    protected final byte[] values;
 
     private final long sizeInBytes;
     private final long retainedSizeInBytes;

--- a/presto-spi/src/main/java/io/prestosql/spi/block/ByteArrayBlockEncoding.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/block/ByteArrayBlockEncoding.java
@@ -13,14 +13,22 @@
  */
 package io.prestosql.spi.block;
 
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
+import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.StandardErrorCode;
+
+import java.io.InputStream;
+import java.io.OutputStream;
 
 import static io.prestosql.spi.block.EncoderUtil.decodeNullBits;
 import static io.prestosql.spi.block.EncoderUtil.encodeNullsAsBits;
 
 public class ByteArrayBlockEncoding
-        implements BlockEncoding
+        extends AbstractBlockEncoding<ByteArrayBlock>
 {
     public static final String NAME = "BYTE_ARRAY";
 
@@ -60,5 +68,64 @@ public class ByteArrayBlockEncoding
         }
 
         return new ByteArrayBlock(0, positionCount, valueIsNull, values);
+    }
+
+    @Override
+    public void write(Kryo kryo, Output output, ByteArrayBlock block)
+    {
+        int positionCount = block.getPositionCount();
+        output.writeInt(positionCount);
+        output.writeBoolean(block.mayHaveNull());
+        if (block.mayHaveNull()) {
+            output.writeBooleans(block.valueIsNull, 0, positionCount);
+        }
+
+        output.writeBytes(block.values, block.arrayOffset, positionCount);
+    }
+
+    @Override
+    public ByteArrayBlock read(Kryo kryo, Input input, Class<? extends ByteArrayBlock> aClass)
+    {
+        int positionCount = input.readInt();
+        boolean[] valueIsNull = null;
+        if (input.readBoolean()) {
+            valueIsNull = input.readBooleans(positionCount);
+        }
+        byte[] values = input.readBytes(positionCount);
+        return new ByteArrayBlock(0, positionCount, valueIsNull, values);
+    }
+
+    /**
+     * Read a block from the specified input.  The returned
+     * block should begin at the specified position.
+     *
+     * @param blockEncodingSerde
+     * @param input
+     */
+    @Override
+    public Block readBlock(BlockEncodingSerde blockEncodingSerde, InputStream input)
+    {
+        if (!(blockEncodingSerde.getContext() instanceof Kryo) || !(input instanceof Input)) {
+            throw new PrestoException(StandardErrorCode.NOT_SUPPORTED, "Generic readblock not supported for ByteArrayBlock");
+        }
+
+        return this.read((Kryo) blockEncodingSerde.getContext(), (Input) input, ByteArrayBlock.class);
+    }
+
+    /**
+     * Write the specified block to the specified output
+     *
+     * @param blockEncodingSerde
+     * @param output
+     * @param block
+     */
+    @Override
+    public void writeBlock(BlockEncodingSerde blockEncodingSerde, OutputStream output, Block block)
+    {
+        if (!(blockEncodingSerde.getContext() instanceof Kryo) || !(output instanceof Output)) {
+            throw new PrestoException(StandardErrorCode.NOT_SUPPORTED, "Generic write not supported for ByteArrayBlock");
+        }
+
+        this.write((Kryo) blockEncodingSerde.getContext(), (Output) output, (ByteArrayBlock) block);
     }
 }

--- a/presto-spi/src/main/java/io/prestosql/spi/block/DictionaryBlock.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/block/DictionaryBlock.java
@@ -41,8 +41,8 @@ public class DictionaryBlock<T>
 
     private final int positionCount;
     private final Block<T> dictionary;
-    private final int idsOffset;
-    private final int[] ids;
+    protected final int idsOffset;
+    protected final int[] ids;
     private final long retainedSizeInBytes;
     private volatile long sizeInBytes = -1;
     private volatile long logicalSizeInBytes = -1;

--- a/presto-spi/src/main/java/io/prestosql/spi/block/Int128ArrayBlock.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/block/Int128ArrayBlock.java
@@ -38,11 +38,11 @@ public class Int128ArrayBlock
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(Int128ArrayBlock.class).instanceSize();
     public static final int INT128_BYTES = Long.BYTES + Long.BYTES;
 
-    private final int positionOffset;
+    protected final int positionOffset;
     private final int positionCount;
     @Nullable
-    private final boolean[] valueIsNull;
-    private final long[] values;
+    protected final boolean[] valueIsNull;
+    protected final long[] values;
 
     private final long sizeInBytes;
     private final long retainedSizeInBytes;

--- a/presto-spi/src/main/java/io/prestosql/spi/block/Int128ArrayBlockEncoding.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/block/Int128ArrayBlockEncoding.java
@@ -13,14 +13,22 @@
  */
 package io.prestosql.spi.block;
 
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
+import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.StandardErrorCode;
+
+import java.io.InputStream;
+import java.io.OutputStream;
 
 import static io.prestosql.spi.block.EncoderUtil.decodeNullBits;
 import static io.prestosql.spi.block.EncoderUtil.encodeNullsAsBits;
 
 public class Int128ArrayBlockEncoding
-        implements BlockEncoding
+        extends AbstractBlockEncoding<Int128ArrayBlock>
 {
     public static final String NAME = "INT128_ARRAY";
 
@@ -62,5 +70,65 @@ public class Int128ArrayBlockEncoding
         }
 
         return new Int128ArrayBlock(0, positionCount, valueIsNull, values);
+    }
+
+    @Override
+    public void write(Kryo kryo, Output output, Int128ArrayBlock block)
+    {
+        int positionCount = block.getPositionCount();
+        output.writeInt(positionCount);
+        output.writeBoolean(block.mayHaveNull());
+
+        if (block.mayHaveNull()) {
+            output.writeBooleans(block.valueIsNull, 0, positionCount);
+        }
+
+        output.writeLongs(block.values, block.positionOffset, positionCount * 2);
+    }
+
+    @Override
+    public Int128ArrayBlock read(Kryo kryo, Input input, Class<? extends Int128ArrayBlock> aClass)
+    {
+        int positionCount = input.readInt();
+        boolean[] valuesIsNull = null;
+        if (input.readBoolean()) {
+            valuesIsNull = input.readBooleans(positionCount);
+        }
+        long[] values = input.readLongs(positionCount * 2);
+        return new Int128ArrayBlock(0, positionCount, valuesIsNull, values);
+    }
+
+    /**
+     * Read a block from the specified input.  The returned
+     * block should begin at the specified position.
+     *
+     * @param blockEncodingSerde
+     * @param input
+     */
+    @Override
+    public Block readBlock(BlockEncodingSerde blockEncodingSerde, InputStream input)
+    {
+        if (!(blockEncodingSerde.getContext() instanceof Kryo) || !(input instanceof Input)) {
+            throw new PrestoException(StandardErrorCode.NOT_SUPPORTED, "Generic readblock not supported for Int128");
+        }
+
+        return this.read((Kryo) blockEncodingSerde.getContext(), (Input) input, Int128ArrayBlock.class);
+    }
+
+    /**
+     * Write the specified block to the specified output
+     *
+     * @param blockEncodingSerde
+     * @param output
+     * @param block
+     */
+    @Override
+    public void writeBlock(BlockEncodingSerde blockEncodingSerde, OutputStream output, Block block)
+    {
+        if (!(blockEncodingSerde.getContext() instanceof Kryo) || !(output instanceof Output)) {
+            throw new PrestoException(StandardErrorCode.NOT_SUPPORTED, "Generic write not supported for Int128");
+        }
+
+        this.write((Kryo) blockEncodingSerde.getContext(), (Output) output, (Int128ArrayBlock) block);
     }
 }

--- a/presto-spi/src/main/java/io/prestosql/spi/block/IntArrayBlock.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/block/IntArrayBlock.java
@@ -35,11 +35,11 @@ public class IntArrayBlock
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(IntArrayBlock.class).instanceSize();
 
-    private final int arrayOffset;
+    protected final int arrayOffset;
     private final int positionCount;
     @Nullable
-    private final boolean[] valueIsNull;
-    private final int[] values;
+    protected final boolean[] valueIsNull;
+    protected final int[] values;
 
     private final long sizeInBytes;
     private final long retainedSizeInBytes;
@@ -134,12 +134,6 @@ public class IntArrayBlock
     public long getLong(int position, int offset)
     {
         return getInt(position, offset);
-    }
-
-    @Override
-    public String getString(int position, int offset, int length)
-    {
-        return String.valueOf(getInt(position, offset));
     }
 
     @Override

--- a/presto-spi/src/main/java/io/prestosql/spi/block/IntArrayBlockEncoding.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/block/IntArrayBlockEncoding.java
@@ -13,14 +13,22 @@
  */
 package io.prestosql.spi.block;
 
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
+import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.StandardErrorCode;
+
+import java.io.InputStream;
+import java.io.OutputStream;
 
 import static io.prestosql.spi.block.EncoderUtil.decodeNullBits;
 import static io.prestosql.spi.block.EncoderUtil.encodeNullsAsBits;
 
 public class IntArrayBlockEncoding
-        implements BlockEncoding
+        extends AbstractBlockEncoding<IntArrayBlock>
 {
     public static final String NAME = "INT_ARRAY";
 
@@ -60,5 +68,65 @@ public class IntArrayBlockEncoding
         }
 
         return new IntArrayBlock(0, positionCount, valueIsNull, values);
+    }
+
+    @Override
+    public void write(Kryo kryo, Output output, IntArrayBlock block)
+    {
+        int positionCount = block.getPositionCount();
+        output.writeInt(positionCount);
+
+        output.writeBoolean(block.mayHaveNull());
+        if (block.mayHaveNull()) {
+            output.writeBooleans(block.valueIsNull, 0, positionCount);
+        }
+
+        output.writeInts(block.values, block.arrayOffset, positionCount);
+    }
+
+    @Override
+    public IntArrayBlock read(Kryo kryo, Input input, Class<? extends IntArrayBlock> aClass)
+    {
+        int positionCount = input.readInt();
+        boolean[] valuesIsNull = null;
+        if (input.readBoolean()) {
+            valuesIsNull = input.readBooleans(positionCount);
+        }
+        int[] values = input.readInts(positionCount);
+        return new IntArrayBlock(0, positionCount, valuesIsNull, values);
+    }
+
+    /**
+     * Read a block from the specified input.  The returned
+     * block should begin at the specified position.
+     *
+     * @param blockEncodingSerde
+     * @param input
+     */
+    @Override
+    public Block readBlock(BlockEncodingSerde blockEncodingSerde, InputStream input)
+    {
+        if (!(blockEncodingSerde.getContext() instanceof Kryo) || !(input instanceof Input)) {
+            throw new PrestoException(StandardErrorCode.NOT_SUPPORTED, "Generic readblock not supported for IntArrayBlock");
+        }
+
+        return this.read((Kryo) blockEncodingSerde.getContext(), (Input) input, IntArrayBlock.class);
+    }
+
+    /**
+     * Write the specified block to the specified output
+     *
+     * @param blockEncodingSerde
+     * @param output
+     * @param block
+     */
+    @Override
+    public void writeBlock(BlockEncodingSerde blockEncodingSerde, OutputStream output, Block block)
+    {
+        if (!(blockEncodingSerde.getContext() instanceof Kryo) || !(output instanceof Output)) {
+            throw new PrestoException(StandardErrorCode.NOT_SUPPORTED, "Generic write not supported for IntArrayBlock");
+        }
+
+        this.write((Kryo) blockEncodingSerde.getContext(), (Output) output, (IntArrayBlock) block);
     }
 }

--- a/presto-spi/src/main/java/io/prestosql/spi/block/LazyBlockEncoding.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/block/LazyBlockEncoding.java
@@ -16,6 +16,8 @@ package io.prestosql.spi.block;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
 
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.Optional;
 
 public class LazyBlockEncoding
@@ -42,6 +44,18 @@ public class LazyBlockEncoding
     public void writeBlock(BlockEncodingSerde blockEncodingSerde, SliceOutput sliceOutput, Block block)
     {
         // We implemented replacementBlockForWrite, so we will never need to write a lazy block
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Block readBlock(BlockEncodingSerde blockEncodingSerde, InputStream input)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void writeBlock(BlockEncodingSerde blockEncodingSerde, OutputStream output, Block block)
+    {
         throw new UnsupportedOperationException();
     }
 

--- a/presto-spi/src/main/java/io/prestosql/spi/block/LongArrayBlock.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/block/LongArrayBlock.java
@@ -39,11 +39,11 @@ public class LongArrayBlock
     //can we intro operations at block level?, for example join of blocks?
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(LongArrayBlock.class).instanceSize();
 
-    private final int arrayOffset;
+    protected final int arrayOffset;
     private final int positionCount;
     @Nullable
-    private final boolean[] valueIsNull;
-    private final long[] values; //change to use offheap --> accessible by RDMA
+    protected final boolean[] valueIsNull;
+    protected final long[] values; //change to use offheap --> accessible by RDMA
 
     private final long sizeInBytes;
     private final long retainedSizeInBytes;

--- a/presto-spi/src/main/java/io/prestosql/spi/block/LongArrayBlockEncoding.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/block/LongArrayBlockEncoding.java
@@ -13,14 +13,22 @@
  */
 package io.prestosql.spi.block;
 
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
+import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.StandardErrorCode;
+
+import java.io.InputStream;
+import java.io.OutputStream;
 
 import static io.prestosql.spi.block.EncoderUtil.decodeNullBits;
 import static io.prestosql.spi.block.EncoderUtil.encodeNullsAsBits;
 
 public class LongArrayBlockEncoding
-        implements BlockEncoding
+        extends AbstractBlockEncoding<LongArrayBlock>
 {
     public static final String NAME = "LONG_ARRAY";
 
@@ -60,5 +68,65 @@ public class LongArrayBlockEncoding
         }
 
         return new LongArrayBlock(0, positionCount, valueIsNull, values);
+    }
+
+    @Override
+    public void write(Kryo kryo, Output output, LongArrayBlock block)
+    {
+        int positionCount = block.getPositionCount();
+        output.writeInt(positionCount);
+
+        output.writeBoolean(block.mayHaveNull());
+        if (block.mayHaveNull()) {
+            output.writeBooleans(block.valueIsNull, 0, positionCount);
+        }
+
+        output.writeLongs(block.values, block.arrayOffset, positionCount);
+    }
+
+    @Override
+    public LongArrayBlock read(Kryo kryo, Input input, Class<? extends LongArrayBlock> aClass)
+    {
+        int positionCount = input.readInt();
+        boolean[] valuesIsNull = null;
+        if (input.readBoolean()) {
+            valuesIsNull = input.readBooleans(positionCount);
+        }
+        long[] values = input.readLongs(positionCount);
+        return new LongArrayBlock(0, positionCount, valuesIsNull, values);
+    }
+
+    /**
+     * Read a block from the specified input.  The returned
+     * block should begin at the specified position.
+     *
+     * @param blockEncodingSerde
+     * @param input
+     */
+    @Override
+    public Block readBlock(BlockEncodingSerde blockEncodingSerde, InputStream input)
+    {
+        if (!(blockEncodingSerde.getContext() instanceof Kryo) || !(input instanceof Input)) {
+            throw new PrestoException(StandardErrorCode.NOT_SUPPORTED, "Generic readblock not supported for LongArrayBlock");
+        }
+
+        return this.read((Kryo) blockEncodingSerde.getContext(), (Input) input, LongArrayBlock.class);
+    }
+
+    /**
+     * Write the specified block to the specified output
+     *
+     * @param blockEncodingSerde
+     * @param output
+     * @param block
+     */
+    @Override
+    public void writeBlock(BlockEncodingSerde blockEncodingSerde, OutputStream output, Block block)
+    {
+        if (!(blockEncodingSerde.getContext() instanceof Kryo) || !(output instanceof Output)) {
+            throw new PrestoException(StandardErrorCode.NOT_SUPPORTED, "Generic write not supported for LongArrayBlock");
+        }
+
+        this.write((Kryo) blockEncodingSerde.getContext(), (Output) output, (LongArrayBlock) block);
     }
 }

--- a/presto-spi/src/main/java/io/prestosql/spi/block/MapBlockEncoding.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/block/MapBlockEncoding.java
@@ -14,12 +14,18 @@
 
 package io.prestosql.spi.block;
 
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
+import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.StandardErrorCode;
 import io.prestosql.spi.type.MapType;
 import io.prestosql.spi.type.TypeManager;
 import io.prestosql.spi.type.TypeSerde;
 
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.Optional;
 
 import static io.airlift.slice.Slices.wrappedIntArray;
@@ -95,5 +101,74 @@ public class MapBlockEncoding
         sliceInput.readBytes(wrappedIntArray(offsets));
         Optional<boolean[]> mapIsNull = EncoderUtil.decodeNullBits(sliceInput, positionCount);
         return createMapBlockInternal(mapType, 0, positionCount, mapIsNull, offsets, keyBlock, valueBlock, hashTable);
+    }
+
+    @Override
+    public Block readBlock(BlockEncodingSerde blockEncodingSerde, InputStream inputStream)
+    {
+        if (!(inputStream instanceof Input)) {
+            throw new PrestoException(StandardErrorCode.NOT_SUPPORTED, "Wrong inputStream for MapBlock ReadBlock");
+        }
+
+        Input input = (Input) inputStream;
+        MapType mapType = (MapType) TypeSerde.readType(typeManager, input);
+
+        Block keyBlock = blockEncodingSerde.readBlock(input);
+        Block valueBlock = blockEncodingSerde.readBlock(input);
+
+        int hashTableSize = input.readInt();
+        int[] hashTable = input.readInts(hashTableSize);
+
+        if (keyBlock.getPositionCount() != valueBlock.getPositionCount() || keyBlock.getPositionCount() * HASH_MULTIPLIER != hashTable.length) {
+            throw new IllegalArgumentException(
+                    format("Deserialized MapBlock violates invariants: key %d, value %d, hash %d", keyBlock.getPositionCount(), valueBlock.getPositionCount(), hashTable.length));
+        }
+
+        int positionCount = input.readInt();
+        int[] offsets = input.readInts(positionCount + 1);
+        Optional<boolean[]> mapIsNull = Optional.empty();
+        if (input.readBoolean()) {
+            mapIsNull = Optional.of(input.readBooleans(positionCount));
+        }
+
+        return createMapBlockInternal(mapType, 0, positionCount, mapIsNull, offsets, keyBlock, valueBlock, hashTable);
+    }
+
+    @Override
+    public void writeBlock(BlockEncodingSerde blockEncodingSerde, OutputStream outputStream, Block block)
+    {
+        if (!(outputStream instanceof Output)) {
+            throw new PrestoException(StandardErrorCode.NOT_SUPPORTED, "Wrong outputStream for SingleMap WriteBlock");
+        }
+
+        Output output = (Output) outputStream;
+        AbstractMapBlock mapBlock = (AbstractMapBlock) block;
+
+        int positionCount = mapBlock.getPositionCount();
+
+        int offsetBase = mapBlock.getOffsetBase();
+        int[] offsets = mapBlock.getOffsets();
+        int[] hashTable = mapBlock.getHashTables();
+
+        int entriesStartOffset = offsets[offsetBase];
+        int entriesEndOffset = offsets[offsetBase + positionCount];
+
+        TypeSerde.writeType(output, mapBlock.mapType);
+
+        blockEncodingSerde.writeBlock(output, mapBlock.getRawKeyBlock().getRegion(entriesStartOffset, entriesEndOffset - entriesStartOffset));
+        blockEncodingSerde.writeBlock(output, mapBlock.getRawValueBlock().getRegion(entriesStartOffset, entriesEndOffset - entriesStartOffset));
+
+        output.writeInt((entriesEndOffset - entriesStartOffset) * HASH_MULTIPLIER);
+        output.writeInts(hashTable, entriesStartOffset * HASH_MULTIPLIER, (entriesEndOffset - entriesStartOffset) * HASH_MULTIPLIER);
+
+        output.writeInt(positionCount);
+        for (int position = 0; position < positionCount + 1; position++) {
+            output.writeInt(offsets[offsetBase + position] - entriesStartOffset);
+        }
+
+        output.writeBoolean(block.mayHaveNull());
+        if (block.mayHaveNull()) {
+            output.writeBooleans(mapBlock.getMapIsNull(), mapBlock.getOffsetBase(), positionCount);
+        }
     }
 }

--- a/presto-spi/src/main/java/io/prestosql/spi/block/RowBlockEncoding.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/block/RowBlockEncoding.java
@@ -14,8 +14,15 @@
 
 package io.prestosql.spi.block;
 
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
+import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.StandardErrorCode;
+
+import java.io.InputStream;
+import java.io.OutputStream;
 
 import static io.airlift.slice.Slices.wrappedIntArray;
 import static io.prestosql.spi.block.RowBlock.createRowBlockInternal;
@@ -70,5 +77,67 @@ public class RowBlockEncoding
         sliceInput.readBytes(wrappedIntArray(fieldBlockOffsets));
         boolean[] rowIsNull = EncoderUtil.decodeNullBits(sliceInput, positionCount).orElseGet(() -> new boolean[positionCount]);
         return createRowBlockInternal(0, positionCount, rowIsNull, fieldBlockOffsets, fieldBlocks);
+    }
+
+    @Override
+    public Block readBlock(BlockEncodingSerde blockEncodingSerde, InputStream inputStream)
+    {
+        if (!(inputStream instanceof Input)) {
+            throw new PrestoException(StandardErrorCode.NOT_SUPPORTED, "Wrong inputStream for SingleRow ReadBlock");
+        }
+
+        Input input = (Input) inputStream;
+        int numFields = input.readInt();
+        Block[] fieldBlocks = new Block[numFields];
+        for (int i = 0; i < fieldBlocks.length; i++) {
+            fieldBlocks[i] = blockEncodingSerde.readBlock(input);
+        }
+
+        int positionCount = input.readInt();
+        int[] fieldBlockOffsets = input.readInts(positionCount);
+        boolean[] rowIsNull;
+
+        if (input.readBoolean()) {
+            rowIsNull = input.readBooleans(positionCount);
+        }
+        else {
+            rowIsNull = new boolean[positionCount];
+        }
+
+        return createRowBlockInternal(0, positionCount, rowIsNull, fieldBlockOffsets, fieldBlocks);
+    }
+
+    @Override
+    public void writeBlock(BlockEncodingSerde blockEncodingSerde, OutputStream outputStream, Block block)
+    {
+        if (!(outputStream instanceof Output)) {
+            throw new PrestoException(StandardErrorCode.NOT_SUPPORTED, "Wrong outputStream for RowBlock WriteBlock");
+        }
+
+        Output output = (Output) outputStream;
+        AbstractRowBlock rowBlock = (AbstractRowBlock) block;
+        int numFields = rowBlock.numFields;
+
+        int positionCount = rowBlock.getPositionCount();
+
+        int offsetBase = rowBlock.getOffsetBase();
+        int[] fieldBlockOffsets = rowBlock.getFieldBlockOffsets();
+        int startFieldBlockOffset = fieldBlockOffsets[offsetBase];
+        int endFieldBlockOffset = fieldBlockOffsets[offsetBase + positionCount];
+
+        output.writeInt(numFields);
+        for (int i = 0; i < numFields; i++) {
+            blockEncodingSerde.writeBlock(output, rowBlock.getRawFieldBlocks()[i].getRegion(startFieldBlockOffset, endFieldBlockOffset - startFieldBlockOffset));
+        }
+
+        output.writeInt(positionCount);
+        for (int position = 0; position < positionCount + 1; position++) {
+            output.writeInt(fieldBlockOffsets[offsetBase + position] - startFieldBlockOffset);
+        }
+
+        output.writeBoolean(block.mayHaveNull());
+        if (block.mayHaveNull()) {
+            output.writeBooleans(rowBlock.getRowIsNull(), offsetBase, positionCount);
+        }
     }
 }

--- a/presto-spi/src/main/java/io/prestosql/spi/block/ShortArrayBlock.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/block/ShortArrayBlock.java
@@ -35,11 +35,11 @@ public class ShortArrayBlock
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(ShortArrayBlock.class).instanceSize();
 
-    private final int arrayOffset;
+    protected final int arrayOffset;
     private final int positionCount;
     @Nullable
-    private final boolean[] valueIsNull;
-    private final short[] values;
+    protected final boolean[] valueIsNull;
+    protected final short[] values;
 
     private final long sizeInBytes;
     private final long retainedSizeInBytes;

--- a/presto-spi/src/main/java/io/prestosql/spi/block/ShortArrayBlockEncoding.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/block/ShortArrayBlockEncoding.java
@@ -13,14 +13,22 @@
  */
 package io.prestosql.spi.block;
 
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
+import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.StandardErrorCode;
+
+import java.io.InputStream;
+import java.io.OutputStream;
 
 import static io.prestosql.spi.block.EncoderUtil.decodeNullBits;
 import static io.prestosql.spi.block.EncoderUtil.encodeNullsAsBits;
 
 public class ShortArrayBlockEncoding
-        implements BlockEncoding
+        extends AbstractBlockEncoding<ShortArrayBlock>
 {
     public static final String NAME = "SHORT_ARRAY";
 
@@ -60,5 +68,65 @@ public class ShortArrayBlockEncoding
         }
 
         return new ShortArrayBlock(0, positionCount, valueIsNull, values);
+    }
+
+    @Override
+    public void write(Kryo kryo, Output output, ShortArrayBlock block)
+    {
+        int positionCount = block.getPositionCount();
+        output.writeInt(positionCount);
+
+        output.writeBoolean(block.mayHaveNull());
+        if (block.mayHaveNull()) {
+            output.writeBooleans(block.valueIsNull, 0, positionCount);
+        }
+
+        output.writeShorts(block.values, block.arrayOffset, positionCount);
+    }
+
+    @Override
+    public ShortArrayBlock read(Kryo kryo, Input input, Class<? extends ShortArrayBlock> aClass)
+    {
+        int positionCount = input.readInt();
+        boolean[] valuesIsNull = null;
+        if (input.readBoolean()) {
+            valuesIsNull = input.readBooleans(positionCount);
+        }
+        short[] values = input.readShorts(positionCount);
+        return new ShortArrayBlock(0, positionCount, valuesIsNull, values);
+    }
+
+    /**
+     * Read a block from the specified input.  The returned
+     * block should begin at the specified position.
+     *
+     * @param blockEncodingSerde
+     * @param input
+     */
+    @Override
+    public Block readBlock(BlockEncodingSerde blockEncodingSerde, InputStream input)
+    {
+        if (!(blockEncodingSerde.getContext() instanceof Kryo) || !(input instanceof Input)) {
+            throw new PrestoException(StandardErrorCode.NOT_SUPPORTED, "Generic readblock not supported for ShortArrayBlock");
+        }
+
+        return this.read((Kryo) blockEncodingSerde.getContext(), (Input) input, ShortArrayBlock.class);
+    }
+
+    /**
+     * Write the specified block to the specified output
+     *
+     * @param blockEncodingSerde
+     * @param output
+     * @param block
+     */
+    @Override
+    public void writeBlock(BlockEncodingSerde blockEncodingSerde, OutputStream output, Block block)
+    {
+        if (!(blockEncodingSerde.getContext() instanceof Kryo) || !(output instanceof Output)) {
+            throw new PrestoException(StandardErrorCode.NOT_SUPPORTED, "Generic write not supported for ShortArrayBlock");
+        }
+
+        this.write((Kryo) blockEncodingSerde.getContext(), (Output) output, (ShortArrayBlock) block);
     }
 }

--- a/presto-spi/src/main/java/io/prestosql/spi/block/SingleMapBlockEncoding.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/block/SingleMapBlockEncoding.java
@@ -14,11 +14,18 @@
 
 package io.prestosql.spi.block;
 
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
+import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.StandardErrorCode;
 import io.prestosql.spi.type.MapType;
 import io.prestosql.spi.type.TypeManager;
 import io.prestosql.spi.type.TypeSerde;
+
+import java.io.InputStream;
+import java.io.OutputStream;
 
 import static io.airlift.slice.Slices.wrappedIntArray;
 import static io.prestosql.spi.block.AbstractMapBlock.HASH_MULTIPLIER;
@@ -75,5 +82,66 @@ public class SingleMapBlockEncoding
         }
 
         return new SingleMapBlock(mapType, 0, keyBlock.getPositionCount() * 2, keyBlock, valueBlock, hashTable);
+    }
+
+    /**
+     * Read a block from the specified input.  The returned
+     * block should begin at the specified position.
+     *
+     * @param blockEncodingSerde
+     * @param inputStream
+     */
+    @Override
+    public Block readBlock(BlockEncodingSerde blockEncodingSerde, InputStream inputStream)
+    {
+        if (!(inputStream instanceof Input)) {
+            throw new PrestoException(StandardErrorCode.NOT_SUPPORTED, "Wrong inputStream for SingleMap ReadBlock");
+        }
+
+        Input input = (Input) inputStream;
+        MapType mapType = (MapType) TypeSerde.readType(typeManager, input);
+
+        Block keyBlock = blockEncodingSerde.readBlock(input);
+        Block valueBlock = blockEncodingSerde.readBlock(input);
+
+        int hashTableSize = input.readInt();
+        int[] hashTable = input.readInts(hashTableSize);
+
+        if (keyBlock.getPositionCount() != valueBlock.getPositionCount()
+                || keyBlock.getPositionCount() * HASH_MULTIPLIER != hashTable.length) {
+            throw new IllegalArgumentException(
+                    format("Deserialized SingleMapBlock violates invariants: key %d, value %d, hash %d", keyBlock.getPositionCount(), valueBlock.getPositionCount(), hashTable.length));
+        }
+
+        return new SingleMapBlock(mapType, 0, keyBlock.getPositionCount() * 2, keyBlock, valueBlock, hashTable);
+    }
+
+    /**
+     * Write the specified block to the specified output
+     *
+     * @param blockEncodingSerde
+     * @param outputStream
+     * @param block
+     */
+    @Override
+    public void writeBlock(BlockEncodingSerde blockEncodingSerde, OutputStream outputStream, Block block)
+    {
+        if (!(outputStream instanceof Output)) {
+            throw new PrestoException(StandardErrorCode.NOT_SUPPORTED, "Wrong outputStream for SingleMap WriteBlock");
+        }
+
+        Output output = (Output) outputStream;
+        SingleMapBlock singleMapBlock = (SingleMapBlock) block;
+        TypeSerde.writeType(output, singleMapBlock.mapType);
+
+        int offset = singleMapBlock.getOffset();
+        int positionCount = singleMapBlock.getPositionCount();
+
+        blockEncodingSerde.writeBlock(output, singleMapBlock.getRawKeyBlock().getRegion(offset / 2, positionCount / 2));
+        blockEncodingSerde.writeBlock(output, singleMapBlock.getRawValueBlock().getRegion(offset / 2, positionCount / 2));
+
+        int[] hashTable = singleMapBlock.getHashTable();
+        output.writeInt(positionCount / 2 * HASH_MULTIPLIER);
+        output.writeInts(hashTable, offset / 2 * HASH_MULTIPLIER, positionCount / 2 * HASH_MULTIPLIER);
     }
 }

--- a/presto-spi/src/main/java/io/prestosql/spi/block/SingleRowBlockEncoding.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/block/SingleRowBlockEncoding.java
@@ -14,8 +14,15 @@
 
 package io.prestosql.spi.block;
 
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
+import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.StandardErrorCode;
+
+import java.io.InputStream;
+import java.io.OutputStream;
 
 public class SingleRowBlockEncoding
         implements BlockEncoding
@@ -49,5 +56,54 @@ public class SingleRowBlockEncoding
             fieldBlocks[i] = blockEncodingSerde.readBlock(sliceInput);
         }
         return new SingleRowBlock(0, fieldBlocks);
+    }
+
+    /**
+     * Read a block from the specified input.  The returned
+     * block should begin at the specified position.
+     *
+     * @param blockEncodingSerde
+     * @param inputStream
+     */
+    @Override
+    public Block readBlock(BlockEncodingSerde blockEncodingSerde, InputStream inputStream)
+    {
+        if (!(inputStream instanceof Input)) {
+            throw new PrestoException(StandardErrorCode.NOT_SUPPORTED, "Wrong inputStream for SingleRow ReadBlock");
+        }
+
+        Input input = (Input) inputStream;
+
+        int numFields = input.readInt();
+        Block[] fieldBlocks = new Block[numFields];
+        for (int i = 0; i < fieldBlocks.length; i++) {
+            fieldBlocks[i] = blockEncodingSerde.readBlock(input);
+        }
+
+        return new SingleRowBlock(0, fieldBlocks);
+    }
+
+    /**
+     * Write the specified block to the specified output
+     *
+     * @param blockEncodingSerde
+     * @param outputStream
+     * @param block
+     */
+    @Override
+    public void writeBlock(BlockEncodingSerde blockEncodingSerde, OutputStream outputStream, Block block)
+    {
+        if (!(outputStream instanceof Output)) {
+            throw new PrestoException(StandardErrorCode.NOT_SUPPORTED, "Wrong outputStream for SingleRowBlock WriteBlock");
+        }
+
+        Output output = (Output) outputStream;
+        SingleRowBlock singleRowBlock = (SingleRowBlock) block;
+        int numFields = singleRowBlock.getNumFields();
+        int rowIndex = singleRowBlock.getRowIndex();
+        output.writeInt(numFields);
+        for (int i = 0; i < numFields; i++) {
+            blockEncodingSerde.writeBlock(output, singleRowBlock.getRawFieldBlock(i).getRegion(rowIndex, 1));
+        }
     }
 }

--- a/presto-spi/src/main/java/io/prestosql/spi/type/TypeSerde.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/TypeSerde.java
@@ -13,6 +13,8 @@
  */
 package io.prestosql.spi.type;
 
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
 
@@ -54,6 +56,39 @@ public final class TypeSerde
     }
 
     private static void writeLengthPrefixedString(SliceOutput output, String string)
+    {
+        byte[] bytes = string.getBytes(UTF_8);
+        output.writeInt(bytes.length);
+        output.writeBytes(bytes);
+    }
+
+    public static void writeType(Output output, Type type)
+    {
+        requireNonNull(output, "output is null");
+        requireNonNull(type, "type is null");
+        writeLengthPrefixedString(output, type.getTypeSignature().toString());
+    }
+
+    public static Type readType(TypeManager typeManager, Input sliceInput)
+    {
+        requireNonNull(sliceInput, "sliceInput is null");
+
+        String name = readLengthPrefixedString(sliceInput);
+        Type type = typeManager.getType(parseTypeSignature(name));
+        if (type == null) {
+            throw new IllegalArgumentException("Unknown type " + name);
+        }
+        return type;
+    }
+
+    private static String readLengthPrefixedString(Input input)
+    {
+        int length = input.readInt();
+        byte[] bytes = input.readBytes(length);
+        return new String(bytes, UTF_8);
+    }
+
+    private static void writeLengthPrefixedString(Output output, String string)
     {
         byte[] bytes = string.getBytes(UTF_8);
         output.writeInt(bytes.length);

--- a/presto-spi/src/test/java/io/prestosql/spi/block/TestInt128ArrayBlockEncoding.java
+++ b/presto-spi/src/test/java/io/prestosql/spi/block/TestInt128ArrayBlockEncoding.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2018-2022. Huawei Technologies Co., Ltd. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.spi.block;
+
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import io.airlift.slice.InputStreamSliceInput;
+import io.airlift.slice.OutputStreamSliceOutput;
+import io.prestosql.spi.type.Type;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Optional;
+
+import static io.prestosql.spi.block.TestingSession.SESSION;
+import static io.prestosql.spi.type.BigintType.BIGINT;
+import static org.testng.Assert.assertEquals;
+
+public class TestInt128ArrayBlockEncoding
+{
+    private final BlockEncodingSerde blockEncodingSerde = new TestingBlockEncodingSerde();
+    private String storePath = "./target/store";
+
+    @BeforeClass
+    public void init()
+    {
+        File dir = new File(storePath);
+        if (!dir.exists()) {
+            dir.mkdirs();
+        }
+    }
+
+    @AfterClass
+    public void teardown()
+    {
+        File dir = new File(storePath);
+        if (dir.exists()) {
+            File[] files = dir.listFiles();
+            for (File file : files) {
+                file.delete();
+            }
+            dir.delete();
+        }
+    }
+
+    @Test
+    public void testRoundTrip() throws IOException
+    {
+        int count = 1024;
+        Int128ArrayBlock expectedBlock = new Int128ArrayBlock(count, Optional.empty(), getValues(count * 2));
+
+        OutputStreamSliceOutput sliceOutput = new OutputStreamSliceOutput(new FileOutputStream(storePath + "/" + "sliceFile.dat"));
+        InputStreamSliceInput sliceInput = new InputStreamSliceInput(new FileInputStream(storePath + "/" + "sliceFile.dat"));
+
+        blockEncodingSerde.writeBlock(sliceOutput, expectedBlock);
+        sliceOutput.close();
+
+        Block actualBlock = blockEncodingSerde.readBlock(sliceInput);
+        sliceInput.close();
+        assertBlockEquals(BIGINT, actualBlock, expectedBlock);
+    }
+
+    @Test
+    public void testRoundTripDirect() throws FileNotFoundException
+    {
+        int count = 1024;
+        Int128ArrayBlock expectedBlock = new Int128ArrayBlock(count, Optional.empty(), getValues(count * 2));
+        Output output = new Output(new FileOutputStream(storePath + "/" + "file.dat"));
+        Input input = new Input(new FileInputStream(storePath + "/" + "file.dat"));
+
+        blockEncodingSerde.writeBlock(output, expectedBlock);
+        output.close();
+
+        Block actualBlock = blockEncodingSerde.readBlock(input);
+        input.close();
+
+        assertBlockEquals(BIGINT, actualBlock, expectedBlock);
+    }
+
+    private long[] getValues(int count)
+    {
+        long[] values = new long[count];
+        for (int i = 0; i < values.length; i++) {
+            values[i] = i;
+        }
+        return values;
+    }
+
+    private static void assertBlockEquals(Type type, Block actual, Block expected)
+    {
+        for (int position = 0; position < actual.getPositionCount(); position++) {
+            assertEquals(type.getObjectValue(SESSION, actual, position), type.getObjectValue(SESSION, expected, position));
+        }
+    }
+}

--- a/presto-spi/src/test/java/io/prestosql/spi/block/TestVariableWidthBlockEncoding.java
+++ b/presto-spi/src/test/java/io/prestosql/spi/block/TestVariableWidthBlockEncoding.java
@@ -13,9 +13,24 @@
  */
 package io.prestosql.spi.block;
 
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.google.common.base.Stopwatch;
 import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.InputStreamSliceInput;
+import io.airlift.slice.OutputStreamSliceOutput;
 import io.prestosql.spi.type.Type;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 import static io.prestosql.spi.block.TestingSession.SESSION;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
@@ -24,6 +39,36 @@ import static org.testng.Assert.assertEquals;
 public class TestVariableWidthBlockEncoding
 {
     private final BlockEncodingSerde blockEncodingSerde = new TestingBlockEncodingSerde();
+    private String storePath = "./target/store";
+
+    private Kryo kryo;
+    private Output output;
+    private Input input;
+
+    @BeforeClass
+    public void init()
+    {
+        kryo = new Kryo();
+        kryo.register(VariableWidthBlock.class);
+
+        File dir = new File(storePath);
+        if (!dir.exists()) {
+            dir.mkdirs();
+        }
+    }
+
+    @AfterClass
+    public void teardown()
+    {
+        File dir = new File(storePath);
+        if (dir.exists()) {
+            File[] files = dir.listFiles();
+            for (File file : files) {
+                file.delete();
+            }
+            dir.delete();
+        }
+    }
 
     @Test
     public void testRoundTrip()
@@ -39,6 +84,86 @@ public class TestVariableWidthBlockEncoding
         blockEncodingSerde.writeBlock(sliceOutput, expectedBlock);
         Block actualBlock = blockEncodingSerde.readBlock(sliceOutput.slice().getInput());
         assertBlockEquals(VARCHAR, actualBlock, expectedBlock);
+    }
+
+    @Test
+    public void testRoundTripKryo() throws FileNotFoundException
+    {
+        output = new Output(new FileOutputStream(storePath + "/" + "file.dat"));
+        input = new Input(new FileInputStream(storePath + "/" + "file.dat"));
+
+        BlockBuilder expectedBlockBuilder = VARCHAR.createBlockBuilder(null, 4);
+        VARCHAR.writeString(expectedBlockBuilder, "alice");
+        VARCHAR.writeString(expectedBlockBuilder, "bob");
+        VARCHAR.writeString(expectedBlockBuilder, "charlie");
+        VARCHAR.writeString(expectedBlockBuilder, "dave");
+        Block expectedBlock = expectedBlockBuilder.build();
+
+        kryo.writeObject(output, expectedBlock);
+        output.close();
+
+        Block actualBlock = kryo.readObject(input, VariableWidthBlock.class);
+        assertBlockEquals(VARCHAR, actualBlock, expectedBlock);
+        input.close();
+    }
+
+    public void testRoundTripKryoPerf100000000() throws IOException
+    {
+        int loopCount = 1000;
+        for (int i = 1; i <= 5; i++) {
+            loopCount *= 10;
+            loopReadWritePerfTest(loopCount);
+        }
+    }
+
+    private void loopReadWritePerfTest(int loopCount) throws IOException
+    {
+        output = new Output(new FileOutputStream(storePath + "/" + "file.dat"));
+        input = new Input(new FileInputStream(storePath + "/" + "file.dat"));
+
+        OutputStreamSliceOutput sliceOutput = new OutputStreamSliceOutput(new FileOutputStream(storePath + "/" + "sliceFile.dat"));
+        InputStreamSliceInput sliceInput = new InputStreamSliceInput(new FileInputStream(storePath + "/" + "sliceFile.dat"));
+
+        BlockBuilder expectedBlockBuilder = VARCHAR.createBlockBuilder(null, 4);
+        VARCHAR.writeString(expectedBlockBuilder, "alice");
+        VARCHAR.writeString(expectedBlockBuilder, "bob");
+        VARCHAR.writeString(expectedBlockBuilder, "charlie");
+        VARCHAR.writeString(expectedBlockBuilder, "dave");
+        Block expectedBlock = expectedBlockBuilder.build();
+
+        Stopwatch watchKryoWrite = Stopwatch.createStarted();
+        for (int i = 0; i < loopCount; i++) {
+            kryo.writeObject(output, expectedBlock);
+        }
+        watchKryoWrite.stop();
+        System.out.println(String.format("[Pages: %,11d] Time to write       [Kryo]: %,7d ms", loopCount, watchKryoWrite.elapsed(TimeUnit.MILLISECONDS)));
+        output.close();
+
+        Stopwatch watchSerDeWrite = Stopwatch.createStarted();
+        for (int i = 0; i < loopCount; i++) {
+            blockEncodingSerde.writeBlock(sliceOutput, expectedBlock);
+        }
+        watchSerDeWrite.stop();
+        System.out.println(String.format("[Pages: %,11d] Time to write [BlockSerDe]: %,7d ms", loopCount, watchSerDeWrite.elapsed(TimeUnit.MILLISECONDS)));
+        sliceOutput.close();
+
+        Stopwatch watchKryoRead = Stopwatch.createStarted();
+        for (int i = 0; i < loopCount; i++) {
+            Block actualBlock = kryo.readObject(input, VariableWidthBlock.class);
+            assertBlockEquals(VARCHAR, actualBlock, expectedBlock);
+        }
+        watchKryoRead.stop();
+        System.out.println(String.format("[Pages: %,11d] Time to read        [Kryo]: %,7d ms", loopCount, watchKryoRead.elapsed(TimeUnit.MILLISECONDS)));
+        input.close();
+
+        Stopwatch watchSerDeRead = Stopwatch.createStarted();
+        for (int i = 0; i < loopCount; i++) {
+            Block actualBlock = blockEncodingSerde.readBlock(sliceInput);
+            assertBlockEquals(VARCHAR, actualBlock, expectedBlock);
+        }
+        watchSerDeRead.stop();
+        System.out.println(String.format("[Pages: %,11d] Time to read  [BlockSerDe]: %,7d ms", loopCount, watchSerDeRead.elapsed(TimeUnit.MILLISECONDS)));
+        input.close();
     }
 
     private static void assertBlockEquals(Type type, Block actual, Block expected)


### PR DESCRIPTION
### What type of PR is this?

Uncomment only one /kind <> line, hit enter to put that in a new line, and remove leading whitespaces from that line:
/kind feature

### What does this PR do / why do we need it:

Integrated Kryo stream serialization:
- Added serializers for Basic Types
- Added serializers for Complex Types like Array, Map, Dict, Row etc
- Added config to enable kryo serializer
- Compression serializers
- Encryption serializers
- Added configuration for direct serializer for kryo

Additionally,
Replaced Mockito-All with Mokito-Core as it conflicts with Kryo for Objenesis jars.
Also, standardized the version used for Mockito-core to 1.10.19 which matches the one used in mockito-all 1.10.18.
Note: Some of the versions of mockito-all used in some of the projects conflicts with other wherein, some interfaces were removed in later versions. Hence, standardization to 1.10.19 was found to be safe in all the usages of all projects as of the time of this PR

### Which issue(s) this PR fixes:

Fixes #277 

### Special notes for your reviewers: