### PR TITLE
Fault detection

### DIFF
--- a/hetu-docs/en/admin/properties.md
+++ b/hetu-docs/en/admin/properties.md
@@ -315,7 +315,20 @@ Exchanges transfer data between openLooKeng nodes for different stages of a quer
 >
 > The maximum amount of time coordinator waits for inter-task related errors to be resolved before it's considered a failure.
 
+### `exchange.is-timeout-failure-detection-enabled`
 
+> -   **Type:** `boolean`
+> -   **Default value:** `true`
+>
+> The failure detection mechanism in use. Default is timeout based failure detection. Otherwise, i.e. when this property is set to false, maximum retry based failure detection mechanism is enabled.
+>
+
+### `exchange.max-retry-count`
+
+> -   **Type:** `integer`
+> -   **Default value:** `10`
+>
+> The maximum number of retry for failed task performed by the coordinator before considering it as a permanent failure. This property is used only when exchange.is-timeout-failure-detection-enabled is set to false.
 ### `sink.max-buffer-size`
 
 > -   **Type:** `data size`

--- a/presto-main/src/main/java/io/prestosql/operator/ExchangeClientConfig.java
+++ b/presto-main/src/main/java/io/prestosql/operator/ExchangeClientConfig.java
@@ -28,6 +28,8 @@ import java.util.concurrent.TimeUnit;
 
 public class ExchangeClientConfig
 {
+    public static final boolean DETECT_TIMEOUT_FAILURES = true;
+    public static final int MAX_RETRY_COUNT = 10;
     private DataSize maxBufferSize = new DataSize(32, Unit.MEGABYTE);
     private int concurrentRequestMultiplier = 3;
     private final Duration minErrorDuration = new Duration(1, TimeUnit.MINUTES);
@@ -36,6 +38,8 @@ public class ExchangeClientConfig
     private int clientThreads = 25;
     private int pageBufferClientMaxCallbackThreads = 25;
     private boolean acknowledgePages = true;
+    private int maxRetryCount = 10;
+    private boolean detectTimeoutFailures = true;
 
     @NotNull
     public DataSize getMaxBufferSize()
@@ -83,11 +87,36 @@ public class ExchangeClientConfig
         return maxErrorDuration;
     }
 
+    @Config("exchange.is-timeout-failure-detection-enabled")
+    public ExchangeClientConfig setDetectTimeoutFailures(boolean b)
+    {
+        this.detectTimeoutFailures = b;
+        return this;
+    }
+
+    public boolean getDetectTimeoutFailures()
+    {
+        return this.detectTimeoutFailures;
+    }
+
     @Config("exchange.max-error-duration")
     public ExchangeClientConfig setMaxErrorDuration(Duration maxErrorDuration)
     {
         this.maxErrorDuration = maxErrorDuration;
         return this;
+    }
+
+    @Config("exchange.max-retry-count")
+    public ExchangeClientConfig setMaxRetryCount(int maxRetryCount)
+    {
+        this.maxRetryCount = maxRetryCount;
+        return this;
+    }
+
+    @Min(1)
+    public int getMaxRetryCount()
+    {
+        return this.maxRetryCount;
     }
 
     @NotNull

--- a/presto-main/src/test/java/io/prestosql/operator/TestExchangeClient.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestExchangeClient.java
@@ -25,6 +25,7 @@ import io.airlift.units.Duration;
 import io.hetu.core.transport.execution.buffer.PagesSerde;
 import io.hetu.core.transport.execution.buffer.SerializedPage;
 import io.prestosql.block.BlockAssertions;
+import io.prestosql.failuredetector.NoOpFailureDetector;
 import io.prestosql.memory.context.SimpleLocalMemoryContext;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.QueryId;
@@ -110,7 +111,7 @@ public class TestExchangeClient
                 new TestingHttpClient(processor, scheduler),
                 scheduler,
                 new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),
-                pageBufferClientCallbackExecutor);
+                pageBufferClientCallbackExecutor, new NoOpFailureDetector());
 
         exchangeClient.addLocation(new TaskLocation(location, instanceId));
         exchangeClient.noMoreLocations();
@@ -156,7 +157,7 @@ public class TestExchangeClient
                 new TestingHttpClient(processor, scheduler),
                 scheduler,
                 new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),
-                pageBufferClientCallbackExecutor);
+                pageBufferClientCallbackExecutor, new NoOpFailureDetector());
         exchangeClient.setSnapshotEnabled(NOOP_SNAPSHOT_UTILS.getQuerySnapshotManager(new QueryId("query")));
 
         final String target1 = "target1";
@@ -211,7 +212,7 @@ public class TestExchangeClient
                 mock(HttpClient.class),
                 scheduler,
                 new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),
-                pageBufferClientCallbackExecutor);
+                pageBufferClientCallbackExecutor, new NoOpFailureDetector());
         exchangeClient.setSnapshotEnabled(NOOP_SNAPSHOT_UTILS.getQuerySnapshotManager(new QueryId("query")));
 
         String origin1 = "location1";
@@ -251,7 +252,7 @@ public class TestExchangeClient
                 new TestingHttpClient(processor, newCachedThreadPool(daemonThreadsNamed("test-%s"))),
                 scheduler,
                 new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),
-                pageBufferClientCallbackExecutor);
+                pageBufferClientCallbackExecutor, new NoOpFailureDetector());
 
         URI location1 = URI.create("http://localhost:8081/foo");
         String instanceId1 = "testing instance id";
@@ -326,7 +327,7 @@ public class TestExchangeClient
                 new TestingHttpClient(processor, newCachedThreadPool(daemonThreadsNamed("test-%s"))),
                 scheduler,
                 new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),
-                pageBufferClientCallbackExecutor);
+                pageBufferClientCallbackExecutor, new NoOpFailureDetector());
 
         exchangeClient.addLocation(new TaskLocation(location, instanceId));
         exchangeClient.noMoreLocations();
@@ -409,7 +410,7 @@ public class TestExchangeClient
                 new TestingHttpClient(processor, newCachedThreadPool(daemonThreadsNamed("test-%s"))),
                 scheduler,
                 new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),
-                pageBufferClientCallbackExecutor);
+                pageBufferClientCallbackExecutor, new NoOpFailureDetector());
         exchangeClient.addLocation(new TaskLocation(location, instanceId));
         exchangeClient.noMoreLocations();
 

--- a/presto-main/src/test/java/io/prestosql/operator/TestExchangeClientConfig.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestExchangeClientConfig.java
@@ -40,7 +40,9 @@ public class TestExchangeClientConfig
                 .setMaxResponseSize(new HttpClientConfig().getMaxContentLength())
                 .setPageBufferClientMaxCallbackThreads(25)
                 .setClientThreads(25)
-                .setAcknowledgePages(true));
+                .setAcknowledgePages(true)
+                .setDetectTimeoutFailures(true)
+                .setMaxRetryCount(10));
     }
 
     @Test
@@ -55,6 +57,8 @@ public class TestExchangeClientConfig
                 .put("exchange.client-threads", "2")
                 .put("exchange.page-buffer-client.max-callback-threads", "16")
                 .put("exchange.acknowledge-pages", "false")
+                .put("exchange.max-retry-count", "100")
+                .put("exchange.is-timeout-failure-detection-enabled", "false")
                 .build();
 
         ExchangeClientConfig expected = new ExchangeClientConfig()
@@ -65,7 +69,9 @@ public class TestExchangeClientConfig
                 .setMaxResponseSize(new DataSize(1, Unit.MEGABYTE))
                 .setClientThreads(2)
                 .setPageBufferClientMaxCallbackThreads(16)
-                .setAcknowledgePages(false);
+                .setAcknowledgePages(false)
+                .setMaxRetryCount(100)
+                .setDetectTimeoutFailures(false);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-main/src/test/java/io/prestosql/operator/TestExchangeOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestExchangeOperator.java
@@ -23,6 +23,7 @@ import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.prestosql.Session;
 import io.prestosql.execution.Lifespan;
+import io.prestosql.failuredetector.NoOpFailureDetector;
 import io.prestosql.metadata.Split;
 import io.prestosql.operator.ExchangeOperator.ExchangeOperatorFactory;
 import io.prestosql.spi.Page;
@@ -96,7 +97,7 @@ public class TestExchangeOperator
                 httpClient,
                 scheduler,
                 systemMemoryUsageListener,
-                pageBufferClientCallbackExecutor);
+                pageBufferClientCallbackExecutor, new NoOpFailureDetector(), true, 3);
     }
 
     @AfterClass(alwaysRun = true)


### PR DESCRIPTION
### What type of PR is this?

/kind feature

### What does this PR do / why do we need it:

Currently, due to timeout based fault detection mechanism, task retry continues for 5 minutes, even if remote worker node is too slow or not available.
Aligning to the fail-first architecture, adding "maximum retry" based failure detection mechanism.
Remote node status is checked from HeartbeatFailureDetector. 
In case node is GONE or UNRESPONSIVE after max-retry-count retries, fail the task.
In case of other node status, continue retrying till timeout happens.

configuration added (to be added in config.properties):
exchange.timeout-failure-detection=true or false
true will enable default timeout based fault detection
false will enable max retry count based fault detection
default is true

in case the above flag is false, the following optional configuration parameter can be used:
exchange.max-retry-count=some-int-number
default value is 10. If nothing is specified, it will be used.
otherwise, max retry number is taken from this parameter specified in config.properties
in case exchange.time-failure-detection=true, this parameter is ignored.

### Which issue(s) this PR fixes:
issue #288
Fixes #

### Special notes for your reviewers: