### PR TITLE
#292 updated default UI execution timeout to 1 day

### DIFF
--- a/presto-main/src/main/java/io/prestosql/queryeditorui/QueryEditorConfig.java
+++ b/presto-main/src/main/java/io/prestosql/queryeditorui/QueryEditorConfig.java
@@ -36,7 +36,7 @@ public class QueryEditorConfig
     private DataSize maxResultSize = new DataSize(1, DataSize.Unit.GIGABYTE);
     private Optional<String> sharedSecret = Optional.empty();
     private Duration sessionTimeout = new Duration(1, DAYS);
-    private Duration executionTimeout = new Duration(15, MINUTES);
+    private Duration executionTimeout = new Duration(1, DAYS);
 
     public boolean isAllowInsecureOverHttp()
     {


### PR DESCRIPTION


### What does this PR do / why do we need it:
It changes the default UI execution timeout to 1 day which is same as session timeout

### Which issue(s) this PR fixes:
#292
