### PR TITLE
#292 #294 updated the ui document to show execution timeout property with its d…

### DIFF
--- a/hetu-docs/en/admin/web-interface.md
+++ b/hetu-docs/en/admin/web-interface.md
@@ -34,3 +34,31 @@ and statistics about the query is available by clicking the *JSON* link. These v
 > -   **Default value:** `false`
 >
 > Insecure authentication over HTTP is disabled by default. This could be overridden via "hetu.queryeditor-ui.allow-insecure-over-http" property of "etc/config.properties" (e.g. hetu.queryeditor-ui.allow-insecure-over-http=true).
+
+### `hetu.queryeditor-ui.execution-timeout`
+
+> -   **Type:** `duration`
+> -   **Default value:** `1 DAYS`>
+>
+> UI Execution timeout is set to 1 day as default. This could be overridden via "hetu.queryeditor-ui.execution-timeout" of "etc/config.properties"
+
+### `hetu.queryeditor-ui.max-result-count`
+
+> - **Type:** `int`
+> - **Default value:** `1000`
+>
+> UI max result count is set to 1000 as default. This could be overridden via "hetu.queryeditor-ui.max-result-count" of "etc/config.properties"
+
+### `hetu.queryeditor-ui.max-result-size-mb`
+
+>- **Type:** `size`
+>- **Default value:** `1GB`
+>
+> UI max result size is set to 1 GB as default. This could be overridden via "hetu.queryeditor-ui.max-result-size-mb" of "etc/config.properties"
+
+### `hetu.queryeditor-ui.session-timeout`
+
+> -   **Type:** `duration`
+> -   **Default value:** `1 DAYS`
+>
+> UI session timeout is set to 1 day as default. This could be overridden via "hetu.queryeditor-ui.session-timeout" of "etc/config.properties"

--- a/presto-main/src/main/java/io/prestosql/queryeditorui/QueryEditorConfig.java
+++ b/presto-main/src/main/java/io/prestosql/queryeditorui/QueryEditorConfig.java
@@ -23,7 +23,6 @@ import javax.validation.constraints.NotNull;
 import java.util.Optional;
 
 import static java.util.concurrent.TimeUnit.DAYS;
-import static java.util.concurrent.TimeUnit.MINUTES;
 
 public class QueryEditorConfig
 {
@@ -36,7 +35,7 @@ public class QueryEditorConfig
     private DataSize maxResultSize = new DataSize(1, DataSize.Unit.GIGABYTE);
     private Optional<String> sharedSecret = Optional.empty();
     private Duration sessionTimeout = new Duration(1, DAYS);
-    private Duration executionTimeout = new Duration(15, MINUTES);
+    private Duration executionTimeout = new Duration(1, DAYS);
 
     public boolean isAllowInsecureOverHttp()
     {


### PR DESCRIPTION
### What type of PR is this?
#294 #292

### What does this PR do / why do we need it:
Currently there is no usage in UI document about hetu.queryeditor-ui.execution-timeout

### Which issue(s) this PR fixes:
Added usage of hetu.queryeditor-ui.execution-timeout in UI document.
