### PR TITLE
updated ui execution timeout to 100 days, also updated document

### DIFF
--- a/hetu-docs/en/admin/web-interface.md
+++ b/hetu-docs/en/admin/web-interface.md
@@ -38,9 +38,9 @@ and statistics about the query is available by clicking the *JSON* link. These v
 ### `hetu.queryeditor-ui.execution-timeout`
 
 > -   **Type:** `duration`
-> -   **Default value:** `1 DAYS`>
+> -   **Default value:** `100 DAYS`>
 >
-> UI Execution timeout is set to 1 day as default. This could be overridden via "hetu.queryeditor-ui.execution-timeout" of "etc/config.properties"
+> UI Execution timeout is set to 100 days as default. This could be overridden via "hetu.queryeditor-ui.execution-timeout" of "etc/config.properties"
 
 ### `hetu.queryeditor-ui.max-result-count`
 

--- a/presto-main/src/main/java/io/prestosql/queryeditorui/QueryEditorConfig.java
+++ b/presto-main/src/main/java/io/prestosql/queryeditorui/QueryEditorConfig.java
@@ -35,7 +35,7 @@ public class QueryEditorConfig
     private DataSize maxResultSize = new DataSize(1, DataSize.Unit.GIGABYTE);
     private Optional<String> sharedSecret = Optional.empty();
     private Duration sessionTimeout = new Duration(1, DAYS);
-    private Duration executionTimeout = new Duration(1, DAYS);
+    private Duration executionTimeout = new Duration(100, DAYS);
 
     public boolean isAllowInsecureOverHttp()
     {


### PR DESCRIPTION
### What type of PR is this?

Updated UI document with missing config variable values.

Also updated ui execution timeout to 100 days as default value.

### Which issue(s) this PR fixes:
#297 
