### PR TITLE
[WIP] Spiller for join and using Spilled buildSide for RightOuter queries

### DIFF
--- a/hetu-heuristic-index/pom.xml
+++ b/hetu-heuristic-index/pom.xml
@@ -98,6 +98,12 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
+        <!--<dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.23.0</version>
+            <scope>test</scope>
+        </dependency>-->
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -436,12 +436,6 @@
             <artifactId>bcprov-jdk15on</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>com.esotericsoftware</groupId>
-            <artifactId>kryo</artifactId>
-            <version>5.0.3</version>
-        </dependency>
-
         <!-- for testing -->
         <dependency>
             <groupId>org.testng</groupId>
@@ -584,6 +578,12 @@
         <dependency>
             <groupId>org.objenesis</groupId>
             <artifactId>objenesis</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.roaringbitmap</groupId>
+            <artifactId>RoaringBitmap</artifactId>
+            <version>0.9.0</version>
         </dependency>
     </dependencies>
 

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -436,6 +436,12 @@
             <artifactId>bcprov-jdk15on</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.esotericsoftware</groupId>
+            <artifactId>kryo</artifactId>
+            <version>5.0.3</version>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>org.testng</groupId>

--- a/presto-main/src/main/java/io/prestosql/execution/scheduler/SqlQueryScheduler.java
+++ b/presto-main/src/main/java/io/prestosql/execution/scheduler/SqlQueryScheduler.java
@@ -772,7 +772,7 @@ public class SqlQueryScheduler
                     }
 
                     // perform some scheduling work
-                    /* Todo(nitin) get groupSize specification from the ResourceGroupManager */
+                    /* Get groupSize specification from the ResourceGroupManager */
                     int maxSplitGroupSize = getOptimalSmallSplitGroupSize();
                     ScheduleResult result = stageSchedulers.get(stage.getStageId())
                             .schedule(maxSplitGroupSize);

--- a/presto-main/src/main/java/io/prestosql/operator/HashBuilderOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/HashBuilderOperator.java
@@ -14,7 +14,10 @@
 package io.prestosql.operator;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableList;
+import com.google.common.hash.BloomFilter;
+import com.google.common.hash.Funnels;
 import com.google.common.io.Closer;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.prestosql.execution.Lifespan;
@@ -22,10 +25,12 @@ import io.prestosql.memory.context.LocalMemoryContext;
 import io.prestosql.snapshot.SingleInputSnapshotState;
 import io.prestosql.snapshot.Spillable;
 import io.prestosql.spi.Page;
+import io.prestosql.spi.block.Block;
 import io.prestosql.spi.plan.PlanNodeId;
 import io.prestosql.spi.snapshot.BlockEncodingSerdeProvider;
 import io.prestosql.spi.snapshot.MarkerPage;
 import io.prestosql.spi.snapshot.RestorableConfig;
+import io.prestosql.spi.type.BigintType;
 import io.prestosql.spiller.SingleStreamSpiller;
 import io.prestosql.spiller.SingleStreamSpillerFactory;
 import io.prestosql.sql.gen.JoinFilterFunctionCompiler.JoinFilterFunctionFactory;
@@ -38,6 +43,7 @@ import java.io.Serializable;
 import java.nio.file.Path;
 import java.util.ArrayDeque;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -239,7 +245,7 @@ public class HashBuilderOperator
 
     private State state = State.CONSUMING_INPUT;
     private Optional<ListenableFuture<?>> lookupSourceNotNeeded = Optional.empty();
-    private final SpilledLookupSourceHandle spilledLookupSourceHandle = new SpilledLookupSourceHandle();
+    private final SpilledLookupSourceHandle spilledLookupSourceHandle;
     private Optional<SingleStreamSpiller> spiller = Optional.empty();
     private ListenableFuture<?> spillInProgress = NOT_BLOCKED;
     private Optional<ListenableFuture<List<Page>>> unspillInProgress = Optional.empty();
@@ -248,6 +254,7 @@ public class HashBuilderOperator
     private OptionalLong lookupSourceChecksum = OptionalLong.empty();
 
     private Optional<Runnable> finishMemoryRevoke = Optional.empty();
+    private final BloomFilter<Long> spillBloom;
 
     private final SingleInputSnapshotState snapshotState;
     // Snapshot: special logic for taking an extra snapshot for HashBuilder operator, for outer joins.
@@ -306,6 +313,15 @@ public class HashBuilderOperator
         this.spillEnabled = spillEnabled;
         this.singleStreamSpillerFactory = requireNonNull(singleStreamSpillerFactory, "singleStreamSpillerFactory is null");
         this.snapshotState = operatorContext.isSnapshotEnabled() ? SingleInputSnapshotState.forOperator(this, operatorContext) : null;
+
+        if (preComputedHashChannel.isPresent() && spillEnabled) {
+            this.spillBloom = BloomFilter.create(Funnels.longFunnel(), 10_000, 0.01);
+        }
+        else {
+            this.spillBloom = null;
+        }
+
+        spilledLookupSourceHandle = new SpilledLookupSourceHandle(spillBloom);
     }
 
     @Override
@@ -408,7 +424,23 @@ public class HashBuilderOperator
     {
         checkState(spillInProgress.isDone(), "Previous spill still in progress");
         checkSuccess(spillInProgress, "spilling failed");
+        updateBloom(page);
         spillInProgress = getSpiller().spill(page);
+    }
+
+    private void updateBloom(Page page)
+    {
+        if (spillBloom == null) {
+            return;
+        }
+
+        int hashChannel = preComputedHashChannel.getAsInt();
+        //Type type = lookupSourceFactory.getTypes().get(hashChannel);
+        Block hashes = page.getBlock(hashChannel);
+        for (int i = 0; i < page.getPositionCount(); i++) {
+            //Todo make generic: spillBloom.put(type.get(hashes, i));
+            spillBloom.put(BigintType.BIGINT.getLong(hashes, i));
+        }
     }
 
     @Override
@@ -463,7 +495,21 @@ public class HashBuilderOperator
                 index.getTypes(),
                 operatorContext.getSpillContext().newLocalSpillContext(),
                 operatorContext.newLocalSystemMemoryContext(HashBuilderOperator.class.getSimpleName())));
-        return getSpiller().spill(index.getPages());
+        return getSpiller().spill(new AbstractIterator<Page>()
+        {
+            private Iterator<Page> spillPages = index.getPages();
+
+            @Override
+            protected Page computeNext()
+            {
+                if (!spillPages.hasNext()) {
+                    return endOfData();
+                }
+                Page page = spillPages.next();
+                updateBloom(page);
+                return page;
+            }
+        });
     }
 
     @Override
@@ -652,6 +698,7 @@ public class HashBuilderOperator
         localUserMemoryContext.setBytes(index.getEstimatedSize().toBytes());
 
         close();
+        spilledLookupSourceHandle.setDisposeCompleted();
     }
 
     private LookupSourceSupplier buildLookupSource()

--- a/presto-main/src/main/java/io/prestosql/operator/JoinBridge.java
+++ b/presto-main/src/main/java/io/prestosql/operator/JoinBridge.java
@@ -30,4 +30,9 @@ public interface JoinBridge
     void destroy();
 
     ListenableFuture<?> whenBuildFinishes();
+
+    default ListenableFuture<?> whenMemProbeFinishes()
+    {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/LookupOuterOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/LookupOuterOperator.java
@@ -124,7 +124,7 @@ public class LookupOuterOperator
 
     private final OperatorContext operatorContext;
     private final LookupSourceFactory lookupSourceFactory;
-    private final ListenableFuture<OuterPositionIterator> outerPositionsFuture;
+    private ListenableFuture<OuterPositionIterator> outerPositionsFuture;
 
     private final List<Type> probeOutputTypes;
     private final Runnable onClose;
@@ -274,7 +274,12 @@ public class LookupOuterOperator
         }
 
         if (outputPositionsFinished) {
-            close();
+            outerPositionsFuture = outerPositions.getNextBatch();
+            outerPositions = null;
+            outerPositions = tryGetFutureValue(outerPositionsFuture).orElse(null);
+            if (outerPositions == null) {
+                close();
+            }
         }
         return page;
     }

--- a/presto-main/src/main/java/io/prestosql/operator/LookupSourceFactory.java
+++ b/presto-main/src/main/java/io/prestosql/operator/LookupSourceFactory.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.operator;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.prestosql.spi.plan.Symbol;
 import io.prestosql.spi.snapshot.MarkerPage;
@@ -45,7 +46,20 @@ public interface LookupSourceFactory
                 i -> {
                     throw new UnsupportedOperationException();
                 },
-                i -> {}));
+                i -> {},
+                i -> {
+                    throw new UnsupportedOperationException();
+                }));
+    }
+
+    default ListenableFuture<PartitionedConsumption<OuterPositionIterator>> startOuterOperator(OptionalInt lookupJoinsCount)
+    {
+        return immediateFuture(new PartitionedConsumption<>(
+                1,
+                ImmutableList.of(1),
+                i -> immediateFuture(null),
+                i -> {},
+                i -> immediateFuture(null)));
     }
 
     /**

--- a/presto-main/src/main/java/io/prestosql/operator/LookupSourceProvider.java
+++ b/presto-main/src/main/java/io/prestosql/operator/LookupSourceProvider.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.operator;
 
+import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.IntPredicate;
 
@@ -33,5 +34,10 @@ public interface LookupSourceProvider
         long spillEpoch();
 
         IntPredicate getSpillMask();
+
+        default BiPredicate<Integer, Long> getSpillMatcher()
+        {
+            return (a, b) -> true;
+        }
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/OuterPositionIterator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/OuterPositionIterator.java
@@ -13,9 +13,17 @@
  */
 package io.prestosql.operator;
 
+import com.google.common.util.concurrent.ListenableFuture;
 import io.prestosql.spi.PageBuilder;
+
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 
 public interface OuterPositionIterator
 {
     boolean appendToNext(PageBuilder pageBuilder, int outputChannelOffset);
+
+    default ListenableFuture<OuterPositionIterator> getNextBatch()
+    {
+        return immediateFuture(null);
+    }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/PartitionedConsumption.java
+++ b/presto-main/src/main/java/io/prestosql/operator/PartitionedConsumption.java
@@ -46,9 +46,10 @@ public final class PartitionedConsumption<T>
     @Nullable
     private List<Partition<T>> partitions;
 
-    public PartitionedConsumption(int consumersCount, Iterable<Integer> partitionNumbers, IntFunction<ListenableFuture<T>> loader, IntConsumer disposer)
+    public PartitionedConsumption(int consumersCount, Iterable<Integer> partitionNumbers, IntFunction<ListenableFuture<T>> loader, IntConsumer disposer,
+                                  IntFunction<ListenableFuture<?>> disposed)
     {
-        this(consumersCount, immediateFuture(null), partitionNumbers, loader, disposer);
+        this(consumersCount, immediateFuture(null), partitionNumbers, loader, disposer, disposed);
     }
 
     public PartitionedConsumption(
@@ -56,18 +57,20 @@ public final class PartitionedConsumption<T>
             ListenableFuture<?> activator,
             Iterable<Integer> partitionNumbers,
             IntFunction<ListenableFuture<T>> loader,
-            IntConsumer disposer)
+            IntConsumer disposer,
+            IntFunction<ListenableFuture<?>> disposed)
     {
         checkArgument(consumersCount > 0, "consumersCount must be positive");
         this.consumersCount = consumersCount;
-        this.partitions = createPartitions(activator, partitionNumbers, loader, disposer);
+        this.partitions = createPartitions(activator, partitionNumbers, loader, disposer, disposed);
     }
 
     private List<Partition<T>> createPartitions(
             ListenableFuture<?> activator,
             Iterable<Integer> partitionNumbers,
             IntFunction<ListenableFuture<T>> loader,
-            IntConsumer disposer)
+            IntConsumer disposer,
+            IntFunction<ListenableFuture<?>> disposed)
     {
         requireNonNull(partitionNumbers, "partitionNumbers is null");
         requireNonNull(loader, "loader is null");
@@ -78,7 +81,7 @@ public final class PartitionedConsumption<T>
         for (Integer partitionNumber : partitionNumbers) {
             Partition<T> partition = new Partition<>(consumersCount, partitionNumber, loader, partitionActivator, disposer);
             partitionList.add(partition);
-            partitionActivator = partition.released;
+            partitionActivator = disposed.apply(partitionNumber);
         }
         return partitionList.build();
     }
@@ -116,7 +119,7 @@ public final class PartitionedConsumption<T>
         private final int partitionNumber;
         private final SettableFuture<?> requested;
         private final ListenableFuture<T> loaded;
-        private final SettableFuture<?> released;
+        private final IntConsumer disposer;
 
         @GuardedBy("this")
         private int pendingReleases;
@@ -134,8 +137,7 @@ public final class PartitionedConsumption<T>
                     allAsList(requested, previousReleased),
                     ignored -> loader.apply(partitionNumber),
                     directExecutor());
-            this.released = SettableFuture.create();
-            released.addListener(() -> disposer.accept(partitionNumber), directExecutor());
+            this.disposer = disposer;
             this.pendingReleases = consumersCount;
         }
 
@@ -156,7 +158,7 @@ public final class PartitionedConsumption<T>
             pendingReleases--;
             checkState(pendingReleases >= 0);
             if (pendingReleases == 0) {
-                released.set(null);
+                disposer.accept(partitionNumber);
             }
         }
     }

--- a/presto-main/src/main/java/io/prestosql/operator/SpilledLookupSourceHandle.java
+++ b/presto-main/src/main/java/io/prestosql/operator/SpilledLookupSourceHandle.java
@@ -14,6 +14,7 @@
 package io.prestosql.operator;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.hash.BloomFilter;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 
@@ -21,6 +22,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -35,7 +37,8 @@ final class SpilledLookupSourceHandle
         SPILLED,
         UNSPILLING,
         PRODUCED,
-        DISPOSED
+        OUTER_CONSUMING,
+        DISPOSE_REQUESTED
     }
 
     @GuardedBy("this")
@@ -48,12 +51,25 @@ final class SpilledLookupSourceHandle
     private SettableFuture<Supplier<LookupSource>> unspilledLookupSource;
 
     private final SettableFuture<?> disposeRequested = SettableFuture.create();
+    private final SettableFuture<?> disposeCompleted = SettableFuture.create();
 
     private final ListenableFuture<?> unspillingOrDisposeRequested = whenAnyComplete(ImmutableList.of(unspillingRequested, disposeRequested));
+
+    private final Optional<BloomFilter<Long>> spillBloom;
+
+    public SpilledLookupSourceHandle(BloomFilter<Long> bloom)
+    {
+        spillBloom = Optional.ofNullable(bloom);
+    }
 
     public SettableFuture<?> getUnspillingRequested()
     {
         return unspillingRequested;
+    }
+
+    public Optional<BloomFilter<Long>> getSpillBloom()
+    {
+        return spillBloom;
     }
 
     public synchronized ListenableFuture<Supplier<LookupSource>> getLookupSource()
@@ -70,7 +86,7 @@ final class SpilledLookupSourceHandle
     {
         requireNonNull(lookupSource, "lookupSource is null");
 
-        if (state == State.DISPOSED) {
+        if (state == State.DISPOSE_REQUESTED) {
             return;
         }
 
@@ -81,16 +97,33 @@ final class SpilledLookupSourceHandle
         setState(State.PRODUCED);
     }
 
+    public synchronized void outerStart()
+    {
+        assertState(State.PRODUCED);
+        setState(State.OUTER_CONSUMING);
+    }
+
     public synchronized void dispose()
     {
         disposeRequested.set(null);
         unspilledLookupSource = null; // let the memory go
-        setState(State.DISPOSED);
+        setState(State.DISPOSE_REQUESTED);
     }
 
     public SettableFuture<?> getDisposeRequested()
     {
         return disposeRequested;
+    }
+
+    public synchronized void setDisposeCompleted()
+    {
+        assertState(State.DISPOSE_REQUESTED);
+        disposeCompleted.set(null);
+    }
+
+    public SettableFuture<?> getDisposeCompleted()
+    {
+        return disposeCompleted;
     }
 
     public ListenableFuture<?> getUnspillingOrDisposeRequested()

--- a/presto-main/src/main/java/io/prestosql/operator/TrackingLookupSourceSupplier.java
+++ b/presto-main/src/main/java/io/prestosql/operator/TrackingLookupSourceSupplier.java
@@ -13,6 +13,8 @@
  */
 package io.prestosql.operator;
 
+import com.google.common.util.concurrent.ListenableFuture;
+
 import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
@@ -22,6 +24,15 @@ public interface TrackingLookupSourceSupplier
     LookupSource getLookupSource();
 
     OuterPositionIterator getOuterPositionIterator();
+
+    default ListenableFuture<?> setOuterPartitionReady(int partition)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    default void updateUnspilledPositions(int partition, long positions)
+    {
+    }
 
     Object captureJoinPositions();
 

--- a/presto-main/src/main/java/io/prestosql/spiller/GenericPartitioningSpiller.java
+++ b/presto-main/src/main/java/io/prestosql/spiller/GenericPartitioningSpiller.java
@@ -39,6 +39,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
 import java.util.function.IntPredicate;
 import java.util.function.Predicate;
 
@@ -63,6 +65,7 @@ public class GenericPartitioningSpiller
 
     private final List<PageBuilder> pageBuilders;
     private final List<Optional<SingleStreamSpiller>> spillers;
+    private final BiFunction<Integer, Page, Long> getRawHash;
 
     private boolean readingStarted;
     private final Set<Integer> spilledPartitions = new HashSet<>();
@@ -72,7 +75,8 @@ public class GenericPartitioningSpiller
             PartitionFunction partitionFunction,
             SpillContext spillContext,
             AggregatedMemoryContext memoryContext,
-            SingleStreamSpillerFactory spillerFactory)
+            SingleStreamSpillerFactory spillerFactory,
+            BiFunction<Integer, Page, Long> getRawHash)
     {
         requireNonNull(spillContext, "spillContext is null");
 
@@ -93,6 +97,7 @@ public class GenericPartitioningSpiller
             spillers.add(Optional.empty());
         }
         this.pageBuilders = tmpPageBuilders.build();
+        this.getRawHash = getRawHash;
     }
 
     @Override
@@ -113,18 +118,24 @@ public class GenericPartitioningSpiller
     @Override
     public synchronized PartitioningSpillResult partitionAndSpill(Page page, IntPredicate spillPartitionMask)
     {
+        return partitionAndSpill(page, spillPartitionMask, (ign1, ign2) -> true);
+    }
+
+    @Override
+    public PartitioningSpillResult partitionAndSpill(Page page, IntPredicate spillPartitionMask, BiPredicate<Integer, Long> spillPartitionMatcher)
+    {
         requireNonNull(page, "page is null");
         requireNonNull(spillPartitionMask, "spillPartitionMask is null");
         checkArgument(page.getChannelCount() == types.size(), "Wrong page channel count, expected %s but got %s", types.size(), page.getChannelCount());
 
         checkState(!readingStarted, "reading already started");
-        IntArrayList unspilledPositions = partitionPage(page, spillPartitionMask);
+        IntArrayList unspilledPositions = partitionPage(page, spillPartitionMask, spillPartitionMatcher);
         ListenableFuture<?> future = flushFullBuilders();
 
         return new PartitioningSpillResult(future, page.getPositions(unspilledPositions.elements(), 0, unspilledPositions.size()));
     }
 
-    private synchronized IntArrayList partitionPage(Page page, IntPredicate spillPartitionMask)
+    private synchronized IntArrayList partitionPage(Page page, IntPredicate spillPartitionMask, BiPredicate<Integer, Long> spillPartitionMatcher)
     {
         IntArrayList unspilledPositions = new IntArrayList();
 
@@ -133,6 +144,10 @@ public class GenericPartitioningSpiller
 
             if (!spillPartitionMask.test(partition)) {
                 unspilledPositions.add(position);
+                continue;
+            }
+
+            if (getRawHash != null && !spillPartitionMatcher.test(partition, getRawHash.apply(position, page))) {
                 continue;
             }
 

--- a/presto-main/src/main/java/io/prestosql/spiller/GenericPartitioningSpillerFactory.java
+++ b/presto-main/src/main/java/io/prestosql/spiller/GenericPartitioningSpillerFactory.java
@@ -17,9 +17,11 @@ import com.google.inject.Inject;
 import io.prestosql.memory.context.AggregatedMemoryContext;
 import io.prestosql.operator.PartitionFunction;
 import io.prestosql.operator.SpillContext;
+import io.prestosql.spi.Page;
 import io.prestosql.spi.type.Type;
 
 import java.util.List;
+import java.util.function.BiFunction;
 
 import static java.util.Objects.requireNonNull;
 
@@ -41,6 +43,12 @@ public class GenericPartitioningSpillerFactory
             SpillContext spillContext,
             AggregatedMemoryContext memoryContext)
     {
-        return new GenericPartitioningSpiller(types, partitionFunction, spillContext, memoryContext, singleStreamSpillerFactory);
+        return new GenericPartitioningSpiller(types, partitionFunction, spillContext, memoryContext, singleStreamSpillerFactory, null);
+    }
+
+    @Override
+    public PartitioningSpiller create(List<Type> types, PartitionFunction partitionFunction, SpillContext spillContext, AggregatedMemoryContext memoryContext, BiFunction<Integer, Page, Long> getRawHash)
+    {
+        return new GenericPartitioningSpiller(types, partitionFunction, spillContext, memoryContext, singleStreamSpillerFactory, getRawHash);
     }
 }

--- a/presto-main/src/main/java/io/prestosql/spiller/PartitioningSpiller.java
+++ b/presto-main/src/main/java/io/prestosql/spiller/PartitioningSpiller.java
@@ -20,6 +20,7 @@ import io.prestosql.spi.snapshot.Restorable;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.function.BiPredicate;
 import java.util.function.IntPredicate;
 
 import static java.util.Objects.requireNonNull;
@@ -34,6 +35,8 @@ public interface PartitioningSpiller
      * This method may not be called if previously initiated spilling is not finished yet.
      */
     PartitioningSpillResult partitionAndSpill(Page page, IntPredicate spillPartitionMask);
+
+    PartitioningSpillResult partitionAndSpill(Page page, IntPredicate spillPartitionMask, BiPredicate<Integer, Long> spillPartitionMatcher);
 
     /**
      * Returns iterator of previously spilled pages from given partition. Callers are expected to call

--- a/presto-main/src/main/java/io/prestosql/spiller/PartitioningSpillerFactory.java
+++ b/presto-main/src/main/java/io/prestosql/spiller/PartitioningSpillerFactory.java
@@ -16,9 +16,11 @@ package io.prestosql.spiller;
 import io.prestosql.memory.context.AggregatedMemoryContext;
 import io.prestosql.operator.PartitionFunction;
 import io.prestosql.operator.SpillContext;
+import io.prestosql.spi.Page;
 import io.prestosql.spi.type.Type;
 
 import java.util.List;
+import java.util.function.BiFunction;
 
 public interface PartitioningSpillerFactory
 {
@@ -27,6 +29,16 @@ public interface PartitioningSpillerFactory
             PartitionFunction partitionFunction,
             SpillContext spillContext,
             AggregatedMemoryContext memoryContext);
+
+    default PartitioningSpiller create(
+            List<Type> types,
+            PartitionFunction partitionFunction,
+            SpillContext spillContext,
+            AggregatedMemoryContext memoryContext,
+            BiFunction<Integer, Page, Long> getRawHash)
+    {
+        return create(types, partitionFunction, spillContext, memoryContext);
+    }
 
     static PartitioningSpillerFactory unsupportedPartitioningSpillerFactory()
     {

--- a/presto-main/src/test/java/io/prestosql/operator/TestHashJoinOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestHashJoinOperator.java
@@ -1930,4 +1930,39 @@ public class TestHashJoinOperator
         }
         assertEquals(matched, 5);
     }
+
+    @Test(timeOut = 30_000)
+    public void testBuildGracefulSpill()
+            throws Exception
+    {
+        TaskStateMachine taskStateMachine = new TaskStateMachine(new TaskId("query", 0, 0), executor);
+        TaskContext taskContext = TestingTaskContext.createTaskContext(executor, scheduledExecutor, TEST_SESSION, taskStateMachine);
+
+        // build factory
+        RowPagesBuilder buildPages = rowPagesBuilder(ImmutableList.of(VARCHAR, BIGINT))
+                .addSequencePage(4, 20, 200);
+
+        DummySpillerFactory buildSpillerFactory = new DummySpillerFactory();
+
+        BuildSideSetup buildSideSetup = setupBuildSide(true, taskContext, Ints.asList(0), buildPages, Optional.empty(), true, buildSpillerFactory);
+        instantiateBuildDrivers(buildSideSetup, taskContext);
+
+        JoinBridgeManager<PartitionedLookupSourceFactory> lookupSourceFactoryManager = buildSideSetup.getLookupSourceFactoryManager();
+        PartitionedLookupSourceFactory lookupSourceFactory = lookupSourceFactoryManager.getJoinBridge(Lifespan.taskWide());
+
+        // finish probe before any build partition is spilled
+        lookupSourceFactory.finishProbeOperator(OptionalInt.of(1));
+
+        // spill build partition after probe is finished
+        HashBuilderOperator hashBuilderOperator = buildSideSetup.getBuildOperators().get(0);
+        hashBuilderOperator.startMemoryRevoke().get();
+        hashBuilderOperator.finishMemoryRevoke();
+        hashBuilderOperator.finish();
+
+        // hash builder operator should not deadlock waiting for spilled lookup source to be disposed
+        hashBuilderOperator.isBlocked().get();
+
+        lookupSourceFactory.destroy();
+        assertTrue(hashBuilderOperator.isFinished());
+    }
 }


### PR DESCRIPTION
### What type of PR is this?
/kind feature

### What does this PR do / why do we need it:
a) Prevent multiple unspills in mem during postMem Join phase.
b) Todo: Memory accounting of bitmap for spilled build pages in Outer flow.
c) Snapshot integration
d) BloomFilter added to eliminate any build spill which don;t match source build.

### Which issue(s) this PR fixes:

Fixes #

### Special notes for your reviewers: