### PR TITLE
issue# 307 fix: Failure detection by maximum retry fail doesnt take the exact value set in exchange.max-retry-count config parameter

### DIFF
--- a/hetu-docs/en/admin/properties.md
+++ b/hetu-docs/en/admin/properties.md
@@ -389,7 +389,7 @@ Exchanges transfer data between openLooKeng nodes for different stages of a quer
 > -   **Type:** `integer`
 > -   **Default value:** `10`
 >
-> The maximum number of retry for failed task performed by the coordinator before considering it as a permanent failure. This property is used only when exchange.is-timeout-failure-detection-enabled is set to false.
+> The maximum number of retry for failed task performed by the coordinator before considering it as a permanent failure. This property is used only when exchange.is-timeout-failure-detection-enabled is set to false. This value needs to be atleast 3 (minimum retry count) to take effect.
 
 ### `sink.max-buffer-size`
 

--- a/presto-main/src/test/java/io/prestosql/operator/TestHttpPageBufferClient.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestHttpPageBufferClient.java
@@ -459,9 +459,9 @@ public class TestHttpPageBufferClient
         assertEquals(callback.getPages().size(), 0);
         assertEquals(callback.getCompletedRequests(), 11);
         assertEquals(callback.getFinishedBuffers(), 0);
-        assertEquals(callback.getFailedBuffers(), 1);
+        assertEquals(callback.getFailedBuffers(), 2);
         assertInstanceOf(callback.getFailure(), PageTransportTimeoutException.class);
-        assertContains(callback.getFailure().getMessage(), WORKER_NODE_ERROR + " (http://localhost:8080/0 - 11 failures,");
+        assertContains(callback.getFailure().getMessage(), WORKER_NODE_ERROR + " (http://localhost:8080/0 - 10 failures,");
         assertStatus(client, location, "queued", 0, 11, 11, 11, "not scheduled");
     }
 


### PR DESCRIPTION
### What type of PR is this?

/kind bug 

### What does this PR do / why do we need it:

for max-retry based failure detection mechanism, exchange.max-retry-count value is used to retry failed task.
Once that number of times retry fails, query is failed.

The issue is: the number of retry happens doesn't match the configured value exchange.max-retry-count.
If exchange.max-retry-count=20 is set, retry happens for 21, 23, 24.. for random number of times which is some value close to 20, but it never is 20.
When exchange.max-retry-count is not set, default value 10 is considered. But retry happens for 15 (or so) times. 

Cause:
failure count is modified using two synchronized methods --> Backoff.failure() and Backoff.maxTried().
Two threads can parallely use these two methods.
Unless read/write of failure count is not made synchronized, the number cannot match the exact expected number in presence of multiple threads.
This fix use synchronized getter and setter methods to read/update failure count value.

### Which issue(s) this PR fixes:

Fixes #307 
https://gitee.com/openlookeng/hetu-core/issues/I4WGE1
### Special notes for your reviewers: