### PR TITLE
[I4VX53] Skipping deletion of the mergefiles incase of cancel-to-resume

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveFileWriter.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveFileWriter.java
@@ -32,6 +32,11 @@ public interface HiveFileWriter
 
     void rollback();
 
+    default void cancel()
+    {
+        rollback();
+    }
+
     long getValidationCpuNanos();
 
     default Optional<Runnable> getVerificationTask()

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveWriter.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveWriter.java
@@ -125,9 +125,14 @@ public class HiveWriter
         return fileWriter.getVerificationTask();
     }
 
-    public void rollback()
+    public void rollback(boolean isCancel)
     {
-        fileWriter.rollback();
+        if (isCancel) {
+            fileWriter.cancel();
+        }
+        else {
+            fileWriter.rollback();
+        }
     }
 
     public PartitionUpdate getPartitionUpdate()

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/OrcFileWriter.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/OrcFileWriter.java
@@ -441,6 +441,26 @@ public class OrcFileWriter
     }
 
     @Override
+    public void cancel()
+    {
+        try {
+            if (deleteDeltaFileWriter.isPresent()) {
+                deleteDeltaFileWriter.get().cancel();
+            }
+            orcWriter.close();
+        }
+        catch (IOException ioException) {
+            /* doNothing
+            *  Issue # [I4VX53] Ignoring IOException here as the files might have been already cleared by
+            *  Coordinator in Cancel to resume flow.
+            */
+        }
+        catch (Exception e) {
+            throw new PrestoException(HIVE_WRITER_CLOSE_ERROR, "Error rolling back write to Hive", e);
+        }
+    }
+
+    @Override
     public long getValidationCpuNanos()
     {
         return validationCpuNanos;


### PR DESCRIPTION
### What type of PR is this?

Uncomment only one /kind <> line, hit enter to put that in a new line, and remove leading whitespaces from that line:

kind bug

### What does this PR do / why do we need it:

Coordinator Cancel-To-Resume, doesnot waits for the operators to finish; it just waits for marking each running task in remote node to Cancel-To-resume.
**Issue: Race-Condition**

1. Coordinator update the Query State to Reschduling -> ForEachStage(CancelToResume)::onAllRemoteNodes()
2. Each worker task manager update the task state as CancelToResume and delete taskReference and returns.
3. However, different task runner drivers still holds the TaskContext for the deleted task; and will start abort/cancel operators as and when a Quanta finishes and operator comes out of execution loop.
4. Before operator can finish, Coordinator Deletes the files generated ORC files (of CTAS tableWriterOperator), and create new task to resume the operation.
5. New Tasks writes the New ORC file.
6. And Older operator now finishes Cancel: as part of which it Deletes the file which NewTask is writing to. {Thereby causing exception as HiveWriter Failed to Commit}

**Summary of the change:**

1. Cancel flow shall not delete any file and shall let Coordinator handle deletion of the files.
2. Operator shall just close the file and exit.


### Which issue(s) this PR fixes:

Fixes #I4VX53

### Special notes for your reviewers: