### PR TITLE
[I44QYL] Fix for Hive Split Source is already closed Issue

### DIFF
--- a/presto-main/src/main/java/io/prestosql/snapshot/MarkerSplitSource.java
+++ b/presto-main/src/main/java/io/prestosql/snapshot/MarkerSplitSource.java
@@ -374,6 +374,8 @@ public class MarkerSplitSource
     public void close()
     {
         announcer.deactivateSplitSource(this);
+        // In case of closing split source before source is exhausted. (e.g. query with limit function).
+        sourceExhausted = true;
         source.close();
     }
 


### PR DESCRIPTION
### What type of PR is this?

Uncomment only one /kind <> line, hit enter to put that in a new line, and remove leading whitespaces from that line:

kind bug

### What does this PR do / why do we need it: Handling Resume Flow in case of query with **limit node** which closes split source before source is exhausted.

### Which issue(s) this PR fixes:

Fixes #I44QYL

### Special notes for your reviewers: