### PR TITLE
[I4PIKD] Document update stating spilling not supported for cross join

### DIFF
--- a/hetu-docs/en/admin/spill.md
+++ b/hetu-docs/en/admin/spill.md
@@ -65,6 +65,8 @@ When the build table is partitioned, the spill-to-disk mechanism can decrease th
 
 With this mechanism, the peak memory used by the join operator can be decreased to the size of the largest build table partition. Assuming no data skew, this will be `1 / task.concurrency` times the size of the whole build table.
 
+Note: spill-to-disk is not supported for Cross Join.
+
 ### Aggregations
 
 Aggregation functions perform an operation on a group of values and return one value. If the number of groups you\'re aggregating over is large, a significant amount of memory may be needed. When spill-to-disk


### PR DESCRIPTION
### What type of PR is this?

Uncomment only one /kind <> line, hit enter to put that in a new line, and remove leading whitespaces from that line:

kind bug

### What does this PR do / why do we need it:  Document update stating spilling not supported for cross join

### Which issue(s) this PR fixes:

Fixes #I4PIKD

### Special notes for your reviewers: