### PR TITLE
Too low value of exchange.max-retry-count doesn't take …

### DIFF
--- a/hetu-docs/en/admin/properties.md
+++ b/hetu-docs/en/admin/properties.md
@@ -387,9 +387,9 @@ Exchanges transfer data between openLooKeng nodes for different stages of a quer
 ### `exchange.max-retry-count`
 
 > -   **Type:** `integer`
-> -   **Default value:** `10`
+> -   **Default value:** `100`
 >
-> The maximum number of retry for failed task performed by the coordinator before considering it as a permanent failure. This property is used only when exchange.is-timeout-failure-detection-enabled is set to false. This value needs to be atleast 3 (minimum retry count) to take effect.
+> The maximum number of retry for failed task performed by the coordinator before consulting the failure detector module about the remote node status. If the remote node status is failed as per the failure detector module, it is considered as a permanent failure. This parameter is the minimum count which is required to decide, not necessarily the exact count. Based on the cluster size, load on the cluster the exact count may vary slightly. This property is used only when exchange.is-timeout-failure-detection-enabled is set to false. This value needs to be at least 100 to take effect.
 
 ### `sink.max-buffer-size`
 

--- a/presto-main/src/main/java/io/prestosql/failuredetector/HeartbeatFailureDetector.java
+++ b/presto-main/src/main/java/io/prestosql/failuredetector/HeartbeatFailureDetector.java
@@ -188,11 +188,16 @@ public class HeartbeatFailureDetector
                     // TODO: distinguish between process unresponsiveness (e.g GC pause) and host reboot
                     return UNRESPONSIVE;
                 }
-
+                if (lastFailureException == null) {
+                    log.debug("State is UNKNOWN. Last Failure Exception is null");
+                }
+                else {
+                    log.debug("State is UNKNOWN. Last Failure exception " + lastFailureException.toString());
+                }
                 return UNKNOWN;
             }
         }
-
+        log.debug("State is UNKNOWN");
         return UNKNOWN;
     }
 

--- a/presto-main/src/main/java/io/prestosql/operator/ExchangeClientConfig.java
+++ b/presto-main/src/main/java/io/prestosql/operator/ExchangeClientConfig.java
@@ -29,7 +29,7 @@ import java.util.concurrent.TimeUnit;
 public class ExchangeClientConfig
 {
     public static final boolean DETECT_TIMEOUT_FAILURES = true;
-    public static final int MAX_RETRY_COUNT = 10;
+    public static final int MAX_RETRY_COUNT = 100;
     private DataSize maxBufferSize = new DataSize(32, Unit.MEGABYTE);
     private int concurrentRequestMultiplier = 3;
     private final Duration minErrorDuration = new Duration(1, TimeUnit.MINUTES);
@@ -38,7 +38,7 @@ public class ExchangeClientConfig
     private int clientThreads = 25;
     private int pageBufferClientMaxCallbackThreads = 25;
     private boolean acknowledgePages = true;
-    private int maxRetryCount = 10;
+    private int maxRetryCount = MAX_RETRY_COUNT;
     private boolean detectTimeoutFailures = true;
 
     @NotNull
@@ -113,7 +113,7 @@ public class ExchangeClientConfig
         return this;
     }
 
-    @Min(1)
+    @Min(100)
     public int getMaxRetryCount()
     {
         return this.maxRetryCount;

--- a/presto-main/src/main/java/io/prestosql/operator/HttpPageBufferClient.java
+++ b/presto-main/src/main/java/io/prestosql/operator/HttpPageBufferClient.java
@@ -438,10 +438,11 @@ public final class HttpPageBufferClient
                          * If node state is gone or unresponsive (e.g. GC pause), immediately fail.
                          * if node is otherwise (e.g.active), keep retrying till timeout of maxErrorDuration
                          */
+                        FailureDetector.State state = failureDetector.getState(fromUri(uri));
+                        log.debug("failure detector state is " + state.toString());
                         hasFailed = (backoff.maxTried() &&
-                                (FailureDetector.State.GONE.equals(failureDetector.getState(fromUri(uri))) ||
-                                        FailureDetector.State.UNRESPONSIVE.equals(failureDetector.getState(fromUri(uri)))))
-                                || backoff.timeout();
+                                !FailureDetector.State.ALIVE.equals(state)
+                                || backoff.timeout());
                     }
                     if (hasFailed) {
                         String message = format("%s (%s - %s failures, failure duration %s, total failed request time %s)",

--- a/presto-main/src/test/java/io/prestosql/operator/TestExchangeClientConfig.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestExchangeClientConfig.java
@@ -42,7 +42,7 @@ public class TestExchangeClientConfig
                 .setClientThreads(25)
                 .setAcknowledgePages(true)
                 .setDetectTimeoutFailures(true)
-                .setMaxRetryCount(10));
+                .setMaxRetryCount(100));
     }
 
     @Test
@@ -57,7 +57,7 @@ public class TestExchangeClientConfig
                 .put("exchange.client-threads", "2")
                 .put("exchange.page-buffer-client.max-callback-threads", "16")
                 .put("exchange.acknowledge-pages", "false")
-                .put("exchange.max-retry-count", "100")
+                .put("exchange.max-retry-count", "110")
                 .put("exchange.is-timeout-failure-detection-enabled", "false")
                 .build();
 
@@ -70,7 +70,7 @@ public class TestExchangeClientConfig
                 .setClientThreads(2)
                 .setPageBufferClientMaxCallbackThreads(16)
                 .setAcknowledgePages(false)
-                .setMaxRetryCount(100)
+                .setMaxRetryCount(110)
                 .setDetectTimeoutFailures(false);
 
         assertFullMapping(properties, expected);

--- a/presto-main/src/test/java/io/prestosql/operator/TestHttpPageBufferClient.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestHttpPageBufferClient.java
@@ -447,22 +447,22 @@ public class TestHttpPageBufferClient
                 ticker,
                 pageBufferClientCallbackExecutor,
                 false,
-                null, new MockNodeCrashFailureDetector(), false, 10);
+                null, new MockNodeCrashFailureDetector(), false, 100);
 
         assertStatus(client, location, "queued", 0, 0, 0, 0, "not scheduled");
 
-        for (int i = 0; i < 11; i++) {
+        for (int i = 0; i < 101; i++) {
             client.scheduleRequest();
             requestComplete.await(10, TimeUnit.SECONDS);
             tickerIncrement.set(new Duration(1, TimeUnit.SECONDS));
         }
         assertEquals(callback.getPages().size(), 0);
-        assertEquals(callback.getCompletedRequests(), 11);
+        assertEquals(callback.getCompletedRequests(), 101);
         assertEquals(callback.getFinishedBuffers(), 0);
         assertEquals(callback.getFailedBuffers(), 2);
         assertInstanceOf(callback.getFailure(), PageTransportTimeoutException.class);
-        assertContains(callback.getFailure().getMessage(), WORKER_NODE_ERROR + " (http://localhost:8080/0 - 10 failures,");
-        assertStatus(client, location, "queued", 0, 11, 11, 11, "not scheduled");
+        assertContains(callback.getFailure().getMessage(), WORKER_NODE_ERROR + " (http://localhost:8080/0 - 100 failures,");
+        assertStatus(client, location, "queued", 0, 101, 101, 101, "not scheduled");
     }
 
     @Test
@@ -493,31 +493,31 @@ public class TestHttpPageBufferClient
                 ticker,
                 pageBufferClientCallbackExecutor,
                 false,
-                null, new MockActiveFailureDetector(), false, 10);
+                null, new MockActiveFailureDetector(), false, 100);
 
         assertStatus(client, location, "queued", 0, 0, 0, 0, "not scheduled");
 
-        for (int i = 0; i < 11; i++) {
+        for (int i = 0; i < 101; i++) {
             client.scheduleRequest();
             requestComplete.await(10, TimeUnit.SECONDS);
             tickerIncrement.set(new Duration(1, TimeUnit.SECONDS));
         }
         assertEquals(callback.getPages().size(), 0);
-        assertEquals(callback.getCompletedRequests(), 11);
+        assertEquals(callback.getCompletedRequests(), 101);
         assertEquals(callback.getFinishedBuffers(), 0);
         assertEquals(callback.getFailedBuffers(), 0);
 
-        assertStatus(client, location, "queued", 0, 11, 11, 11, "not scheduled");
+        assertStatus(client, location, "queued", 0, 101, 101, 101, "not scheduled");
 
         tickerIncrement.set(new Duration(301, TimeUnit.SECONDS));
         client.scheduleRequest();
         requestComplete.await(10, TimeUnit.SECONDS);
 
-        assertEquals(callback.getCompletedRequests(), 12);
+        assertEquals(callback.getCompletedRequests(), 102);
         assertEquals(callback.getFinishedBuffers(), 0);
         assertEquals(callback.getFailedBuffers(), 1);
         assertInstanceOf(callback.getFailure(), PageTransportTimeoutException.class);
-        assertContains(callback.getFailure().getMessage(), WORKER_NODE_ERROR + " (http://localhost:8080/0 - 12 failures,");
+        assertContains(callback.getFailure().getMessage(), WORKER_NODE_ERROR + " (http://localhost:8080/0 - 102 failures,");
     }
 
     @Test

--- a/presto-main/src/test/java/io/prestosql/server/remotetask/TestBackoff.java
+++ b/presto-main/src/test/java/io/prestosql/server/remotetask/TestBackoff.java
@@ -113,15 +113,14 @@ public class TestBackoff
 
         ticker.increment(14, SECONDS);
 
-        for (int i = 2; i < 14; i++) {  // increase failure count to 13
+        for (int i = 2; i < 14; i++) {
             assertFalse(backoff.failure());
             assertEquals(backoff.getFailureCount(), i);
             assertEquals(backoff.getFailureDuration().roundTo(SECONDS), 14 + i - 2);
             ticker.increment(1, SECONDS);
         }
 
-        // max retry = min retry (3) + max retry (10) = 13.
-        assertTrue(backoff.maxTried());
+        assertFalse(backoff.maxTried());
         assertFalse(backoff.timeout()); // 30 s should not elapse
 
         ticker.increment(5, SECONDS);


### PR DESCRIPTION
…effect

### What type of PR is this?

/kind bug

### What does this PR do / why do we need it:

exchange.max-retry-count default value is 100, minimum value is also 100.
When value for this parameter is too low (e.g. < 10), retry happens for more times (e.g. 15 or more) before query fail.

Also, query fails when max-retry-count is reached, and remote node status is unknown.


### Which issue(s) this PR fixes:
https://gitee.com/openlookeng/hetu-core/issues/I4WGE1
Fixes # 


### Special notes for your reviewers: