### PR TITLE
[I4XU9C] Empty Spilled partition identification for outer fixed

### DIFF
--- a/presto-main/src/main/java/io/prestosql/operator/PartitionedLookupSource.java
+++ b/presto-main/src/main/java/io/prestosql/operator/PartitionedLookupSource.java
@@ -499,6 +499,12 @@ public class PartitionedLookupSource
                 if (lookupSources.get(partition).getJoinPositionCount() <= 0
                         || lookupSources.get(partition).getJoinPositionCount() <= visitedPositions.get(partition).getCardinality()) {
                     setPartitionDone(partition); /* all matched in this partition; skip it! */
+                    partitionReady.get(partition)
+                            .set(new PartitionedLookupOuterPositionIterator(
+                                    new LookupSource[0],
+                                    new RoaringBitmap[0],
+                                    new int[0],
+                                    this));
                 }
                 else {
                     partitionReady.get(partition)


### PR DESCRIPTION

### What type of PR is this?

/kind bug 
### What does this PR do / why do we need it:
fixed identification of the empty outer spilled partitions

### Which issue(s) this PR fixes:

Fixes #I4XU9C

### Special notes for your reviewers: