### PR TITLE
[I4MHGW] Fix for Query Restore Failing From Successfully Captured Snapshot Issue

### DIFF
--- a/presto-main/src/main/java/io/prestosql/snapshot/QuerySnapshotManager.java
+++ b/presto-main/src/main/java/io/prestosql/snapshot/QuerySnapshotManager.java
@@ -460,7 +460,7 @@ public class QuerySnapshotManager
     {
         SnapshotComponentCounter<TaskId> counter = captureComponentCounters.computeIfAbsent(snapshotId, k ->
                 // A snapshot is considered complete if tasks either finished their snapshots or have completed
-                new SnapshotComponentCounter<>(ids -> ids.containsAll(unfinishedTasks), (curTaskId, ids) -> CheckAndNotifyStageCaptureCompletion(curTaskId, ids, snapshotId)));
+                new SnapshotComponentCounter<>(ids -> ids.containsAll(unfinishedTasks), (curTaskId, ids) -> CheckAndNotifyStageCaptureCompletion(curTaskId, ids, snapshotId), task -> !unfinishedTasks.contains(task)));
         if (counter.updateComponent(taskId, componentState)) {
             SnapshotResult snapshotResult = counter.getSnapshotResult();
             synchronized (captureResults) {
@@ -493,7 +493,7 @@ public class QuerySnapshotManager
         // update queryToRestoredSnapshotComponentCounterMap
         SnapshotComponentCounter<TaskId> counter = restoreComponentCounters.computeIfAbsent(snapshotId, k ->
                 // A snapshot is considered complete if tasks either finished their snapshots or have completed
-                new SnapshotComponentCounter<>(ids -> ids.containsAll(unfinishedTasks), (curTaskId, ids) -> CheckAndNotifyStageRestoreCompletion(curTaskId, ids)));
+                new SnapshotComponentCounter<>(ids -> ids.containsAll(unfinishedTasks), (curTaskId, ids) -> CheckAndNotifyStageRestoreCompletion(curTaskId, ids), null));
 
         if (counter.updateComponent(taskId, componentState)) {
             LOG.debug("Finished restoring snapshot %d for task %s", snapshotId, taskId);

--- a/presto-main/src/main/java/io/prestosql/snapshot/SnapshotComponentCounter.java
+++ b/presto-main/src/main/java/io/prestosql/snapshot/SnapshotComponentCounter.java
@@ -43,6 +43,8 @@ public class SnapshotComponentCounter<T>
     // Overall result
     private SnapshotResult snapshotResult = SnapshotResult.IN_PROGRESS;
 
+    private Function<T, Boolean> checkFinishedTask = (stateId) -> false;
+
     public SnapshotComponentCounter(int totalComponentCount)
     {
         this.totalComponentCount = totalComponentCount;
@@ -50,11 +52,12 @@ public class SnapshotComponentCounter<T>
         this.checkStageComplete = null;
     }
 
-    public SnapshotComponentCounter(Function<Set<T>, Boolean> checkComplete, BiConsumer<T, Set<T>> checkStageComplete)
+    public SnapshotComponentCounter(Function<Set<T>, Boolean> checkComplete, BiConsumer<T, Set<T>> checkStageComplete, Function<T, Boolean> checkFinishedTask)
     {
         this.totalComponentCount = 0;
         this.checkComplete = checkComplete;
         this.checkStageComplete = checkStageComplete;
+        this.checkFinishedTask = checkFinishedTask;
     }
 
     // Returns whether a change was made
@@ -82,6 +85,9 @@ public class SnapshotComponentCounter<T>
         if (checkComplete != null) {
             if (checkComplete.apply(componentMap.keySet())) {
                 doneResult();
+            }
+            else if (checkFinishedTask != null && checkFinishedTask.apply(stateId)) {
+                return false;
             }
         }
         else {

--- a/presto-main/src/main/java/io/prestosql/snapshot/TaskSnapshotManager.java
+++ b/presto-main/src/main/java/io/prestosql/snapshot/TaskSnapshotManager.java
@@ -272,7 +272,7 @@ public class TaskSnapshotManager
 
     public void failedToRestore(SnapshotStateId componentId, boolean fatal)
     {
-        LOG.debug("Failed (fatal=%b) to restore snapshot %d for component %s", fatal, componentId.getSnapshotId(), componentId);
+        LOG.warn("Failed (fatal=%b) to restore snapshot %d for component %s", fatal, componentId.getSnapshotId(), componentId);
         if (fatal) {
             updateRestore(componentId, SnapshotComponentCounter.ComponentState.FAILED_FATAL);
         }


### PR DESCRIPTION
### What type of PR is this?

Uncomment only one /kind <> line, hit enter to put that in a new line, and remove leading whitespaces from that line:

kind bug 

### What does this PR do / why do we need it: This PR fixes the issue of query restoring successfully from the latest successful snapshot taken by:
1. Skip storing consolidated states in subsequent snapshots for tasks which are already finished.

### Which issue(s) this PR fixes:

Fixes #I4MHGW

### Special notes for your reviewers: