### PR TITLE
[343] Extend Snapshot Support for Spilling in LookUpJoinOperator

### DIFF
--- a/presto-main/src/main/java/io/prestosql/spiller/PartitioningSpiller.java
+++ b/presto-main/src/main/java/io/prestosql/spiller/PartitioningSpiller.java
@@ -13,13 +13,16 @@
  */
 package io.prestosql.spiller;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.snapshot.Restorable;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Iterator;
+import java.util.List;
 import java.util.function.BiPredicate;
 import java.util.function.IntPredicate;
 
@@ -57,6 +60,11 @@ public interface PartitioningSpiller
     @Override
     void close()
             throws IOException;
+
+    default List<Path> getSpilledFilePaths()
+    {
+        return ImmutableList.of();
+    }
 
     class PartitioningSpillResult
     {


### PR DESCRIPTION
### What type of PR is this?

Uncomment only one /kind <> line, hit enter to put that in a new line, and remove leading whitespaces from that line:

kind bug

### What does this PR do / why do we need it: This PR captures PageBuilders Data and Spilled Files as part of snapshot for LookUpJoinOperator

### Which issue(s) this PR fixes:

Fixes #343 

### Special notes for your reviewers: