### PR TITLE
Added Bloom Filter for Orc Files

### DIFF
--- a/hetu-docs/en/connector/hive.md
+++ b/hetu-docs/en/connector/hive.md
@@ -567,6 +567,24 @@ VACUUM TABLE hive_acid_table_partitioned
 
 
 
+## Table Properties
+
+Bloom Index is supported for both transactional and non-transactional tables. Support is added for real, date, timestamp and char datatypes.
+
+| Property Name                    | Data type      | Description                                                        | Default  |
+|:---------------------------------|:---------------|:-------------------------------------------------------------------|:---------|
+| `orc_bloom_filter_columns`       | array(varchar) | Bloom Filter Index columns for ORC files as a comma seperated list |          |
+| `orc_bloom_filter_fpp`           | double         | False positive probability of bloom filter                         | `0.05`   |
+
+Example: Creating a table with bloom columns specified:
+
+```sql
+CREATE TABLE testbloom 
+  (a bigint, b row(c bigint, d bigint), e row(f double, g date))  
+  WITH (format='orc',transactional=true, 
+  orc_bloom_filter_columns=ARRAY['a','b.c','e'], orc_bloom_filter_fpp=0.001);
+```
+
 ## Schema Evolution
 
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
@@ -11,6 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.prestosql.plugin.hive;
 
 import com.google.common.base.Joiner;
@@ -185,6 +186,7 @@ import static io.prestosql.testing.TestingSession.testSessionBuilder;
 import static io.prestosql.testing.TestingSnapshotUtils.NOOP_SNAPSHOT_UTILS;
 import static io.prestosql.testing.assertions.Assert.assertEquals;
 import static io.prestosql.tests.QueryAssertions.assertEqualsIgnoreOrder;
+import static io.prestosql.tests.sql.TestTable.randomTableSuffix;
 import static io.prestosql.transaction.TransactionBuilder.transaction;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -6939,5 +6941,110 @@ public class TestHiveIntegrationSmokeTest
         assertEquals(computeActual("SELECT * FROM testReadSchema4.testReadStruct9").getRowCount(), 1);
         assertUpdate("DROP TABLE testReadSchema4.testReadStruct9");
         assertUpdate("DROP SCHEMA testReadSchema4");
+    }
+
+    @Test
+    public void testInvalidOrcBloomFilterProperty()
+    {
+        assertThatThrownBy(() -> assertUpdate("CREATE TABLE invalid_bloom_fpp (col1 bigint) WITH (format = 'ORC', orc_bloom_filter_columns = ARRAY['col1'], orc_bloom_filter_fpp=2)"))
+                .hasMessageMatching("Invalid value for orc_bloom_filter_fpp property: 2.0");
+        assertThatThrownBy(() -> assertUpdate("CREATE TABLE invalid_bloom_fpp (col1 bigint) WITH (format = 'ORC', orc_bloom_filter_columns = ARRAY['col1'], orc_bloom_filter_fpp=a)"))
+                .hasMessageStartingWith("Invalid value for table property 'orc_bloom_filter_fpp'");
+    }
+
+    @Test
+    public void testOrcBloomFilterWrittenForTransactionalTables()
+    {
+        String tableName = "bloom_for_txn_table_" + randomTableSuffix();
+        test_bloom_written_during_create(tableName, true);
+
+        tableName = "bloom_for_txn_table_" + randomTableSuffix();
+        test_bloom_written_during_insert(tableName, true);
+    }
+
+    @Test
+    public void testOrcBloomFilterWrittenForNonTransactionalTables()
+    {
+        String tableName = "bloom_for_non_txn_table_" + randomTableSuffix();
+        test_bloom_written_during_create(tableName, false);
+
+        tableName = "bloom_for_non_txn_table_" + randomTableSuffix();
+        test_bloom_written_during_insert(tableName, false);
+    }
+
+    private void test_bloom_written_during_create(String tableName, boolean transactional)
+    {
+        // test for bloom is getting written for create table query
+        assertUpdate(format("drop table if exists %s", tableName));
+        assertUpdate(
+                format(
+                        "create table %s WITH (%s) as select * from tpch.tiny.lineitem",
+                        tableName,
+                        addTableProperties("ORC", transactional, "orderkey", 0.001)),
+                60175);
+        assertBloomFilterBasedRowGroupPruning(format("select * from %s where orderkey = 29989", tableName));
+
+        // test to check bloom still takes effect on rename column
+        assertUpdate(
+                format(
+                        "alter table %s rename column orderkey to alt_orderkey", tableName));
+        assertBloomFilterBasedRowGroupPruning(format("select * from %s where alt_orderkey = 29989", tableName));
+        assertUpdate(format("DROP TABLE %s", tableName));
+    }
+
+    private void test_bloom_written_during_insert(String tableName, boolean transactional)
+    {
+        // test for bloom is getting written for insert query
+        assertUpdate(format("drop table if exists %s", tableName));
+        assertUpdate(
+                format(
+                        "create table %s (orderkey bigint, partkey bigint, shipmode VARCHAR(10)) WITH (%s)",
+                        tableName,
+                        addTableProperties("ORC", transactional, "orderkey", 0.001)));
+        assertUpdate(
+                format(
+                        "INSERT INTO %s SELECT orderkey, partkey, shipmode from tpch.tiny.lineitem",
+                        tableName),
+                60175);
+        assertBloomFilterBasedRowGroupPruning(format("select * from %s where orderkey = 29989", tableName));
+        assertUpdate(format("DROP TABLE %s", tableName));
+    }
+
+    private String addTableProperties(String fileFormat, boolean transactional, String bloomFilterColumnName, double fpp)
+    {
+        return format(
+                "format = '%s', transactional = %s, orc_bloom_filter_columns = ARRAY['%s'], orc_bloom_filter_fpp = %s",
+                fileFormat,
+                transactional,
+                bloomFilterColumnName,
+                fpp);
+    }
+
+    private void assertBloomFilterBasedRowGroupPruning(@Language("SQL") String sql)
+    {
+        assertQueryStats(
+                enableBloomFilters(getSession(), false),
+                sql,
+                queryStats -> {
+                    assertThat(queryStats.getPhysicalInputPositions()).isGreaterThan(0);
+                    assertThat(queryStats.getProcessedInputPositions()).isEqualTo(queryStats.getPhysicalInputPositions());
+                },
+                results -> assertThat(results.getRowCount()).isEqualTo(2));
+
+        assertQueryStats(
+                enableBloomFilters(getSession(), true),
+                sql,
+                queryStats -> {
+                    assertThat(queryStats.getPhysicalInputPositions()).isGreaterThan(0);
+                    assertThat(queryStats.getProcessedInputPositions()).isGreaterThan(0);
+                },
+                results -> assertThat(results.getRowCount()).isEqualTo(2));
+    }
+
+    private Session enableBloomFilters(Session session, boolean value)
+    {
+        return Session.builder(session)
+                .setCatalogSessionProperty(session.getCatalog().get(), "orc_bloom_filters_enabled", String.valueOf(value))
+                .build();
     }
 }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/util/TestOrcWriterOptions.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/util/TestOrcWriterOptions.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2018-2022. Huawei Technologies Co., Ltd. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.prestosql.plugin.hive.util;
+
+import io.airlift.units.DataSize;
+import io.prestosql.orc.OrcWriterOptions;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Properties;
+
+import static io.airlift.units.DataSize.Unit.BYTE;
+import static io.airlift.units.DataSize.Unit.KILOBYTE;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static io.prestosql.plugin.hive.HiveMetadata.ORC_BLOOM_FILTER_COLUMNS_KEY;
+import static io.prestosql.plugin.hive.HiveMetadata.ORC_BLOOM_FILTER_FPP_KEY;
+import static io.prestosql.plugin.hive.OrcFileWriterFactory.getOrcWriterBloomOptions;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+public class TestOrcWriterOptions
+{
+    @Test
+    public void testDefaults()
+    {
+        OrcWriterOptions orcWriterOptions = new OrcWriterOptions();
+        assertThat(orcWriterOptions.getStripeMinSize()).isEqualTo(new DataSize(32, MEGABYTE));
+        assertThat(orcWriterOptions.getStripeMaxSize()).isEqualTo(new DataSize(64, MEGABYTE));
+        assertThat(orcWriterOptions.getStripeMaxRowCount()).isEqualTo(10_000_000);
+        assertThat(orcWriterOptions.getRowGroupMaxRowCount()).isEqualTo(10_000);
+        assertThat(orcWriterOptions.getDictionaryMaxMemory()).isEqualTo(new DataSize(16, MEGABYTE));
+        assertThat(orcWriterOptions.getMaxStringStatisticsLimit()).isEqualTo(new DataSize(64, BYTE));
+        assertThat(orcWriterOptions.getMaxCompressionBufferSize()).isEqualTo(new DataSize(256, KILOBYTE));
+        assertThat(orcWriterOptions.getBloomFilterFpp()).isEqualTo(0.05);
+        assertThat(orcWriterOptions.isBloomFilterColumn("unknown_bloom_column")).isFalse();
+    }
+
+    @Test
+    public void testOrcWriterOptionsFromTableProperties()
+    {
+        Properties tableProperties = new Properties();
+        tableProperties.setProperty(ORC_BLOOM_FILTER_COLUMNS_KEY, "test_column_a, test_column_b");
+        tableProperties.setProperty(ORC_BLOOM_FILTER_FPP_KEY, "0.1");
+        OrcWriterOptions orcWriterOptions = getOrcWriterBloomOptions(tableProperties, new OrcWriterOptions());
+
+        assertThat(orcWriterOptions.isBloomFilterColumn("test_column_a")).isTrue();
+        assertThat(orcWriterOptions.isBloomFilterColumn("test_column_b")).isTrue();
+        assertThat(orcWriterOptions.isBloomFilterColumn("unknown_bloom_column")).isFalse();
+
+        assertThat(orcWriterOptions.getBloomFilterFpp()).isEqualTo(0.1);
+        assertThat(orcWriterOptions.getBloomFilterFpp()).isNotEqualTo(0.5);
+    }
+
+    @Test(dataProvider = "invalidBloomFilterFpp")
+    public void testOrcWriterOptionsWithInvalidFPPValue(String fpp)
+    {
+        Properties tableProperties = new Properties();
+        tableProperties.setProperty(ORC_BLOOM_FILTER_COLUMNS_KEY, "column_with_bloom_filter");
+        tableProperties.setProperty(ORC_BLOOM_FILTER_FPP_KEY, fpp);
+        assertThatThrownBy(() -> getOrcWriterBloomOptions(tableProperties, new OrcWriterOptions()))
+                .hasMessage("Invalid value for orc_bloom_filter_fpp property: " + fpp);
+    }
+
+    @Test(dataProvider = "invalidRangeBloomFilterFpp")
+    public void testOrcBloomFilterWithInvalidRange(String fpp)
+    {
+        Properties tableProperties = new Properties();
+        tableProperties.setProperty(ORC_BLOOM_FILTER_COLUMNS_KEY, "column_with_bloom_filter");
+        tableProperties.setProperty(ORC_BLOOM_FILTER_FPP_KEY, fpp);
+        assertThatThrownBy(() -> getOrcWriterBloomOptions(tableProperties, new OrcWriterOptions()))
+                .hasMessage("bloomFilterFpp should be > 0.0 & < 1.0");
+    }
+
+    @DataProvider
+    public Object[][] invalidBloomFilterFpp()
+    {
+        return new Object[][] {
+                {"abc"},
+                {"12c"},
+                {"$"},
+                {"*"}
+        };
+    }
+
+    @DataProvider
+    public Object[][] invalidRangeBloomFilterFpp()
+    {
+        return new Object[][] {
+                {"10"},
+                {"-10"},
+                {"0"},
+                {"1"}
+        };
+    }
+}

--- a/presto-orc/src/main/java/io/prestosql/orc/OrcWriteValidation.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/OrcWriteValidation.java
@@ -34,12 +34,14 @@ import io.prestosql.orc.metadata.statistics.DoubleStatisticsBuilder;
 import io.prestosql.orc.metadata.statistics.IntegerStatistics;
 import io.prestosql.orc.metadata.statistics.IntegerStatisticsBuilder;
 import io.prestosql.orc.metadata.statistics.LongDecimalStatisticsBuilder;
+import io.prestosql.orc.metadata.statistics.NoOpBloomFilterBuilder;
 import io.prestosql.orc.metadata.statistics.ShortDecimalStatisticsBuilder;
 import io.prestosql.orc.metadata.statistics.StatisticsBuilder;
 import io.prestosql.orc.metadata.statistics.StatisticsHasher;
 import io.prestosql.orc.metadata.statistics.StringStatistics;
 import io.prestosql.orc.metadata.statistics.StringStatisticsBuilder;
 import io.prestosql.orc.metadata.statistics.StripeStatistics;
+import io.prestosql.orc.metadata.statistics.TimestampStatisticsBuilder;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.block.Block;
@@ -604,7 +606,7 @@ public class OrcWriteValidation
                 return Optional.empty();
             }
             ImmutableList.Builder<ColumnStatistics> statisticsBuilders = ImmutableList.builder();
-            statisticsBuilders.add(new ColumnStatistics(rowCount, 0, null, null, null, null, null, null, null, null));
+            statisticsBuilders.add(new ColumnStatistics(rowCount, 0, null, null, null, null, null, null, null, null, null));
             columnStatisticsValidations.forEach(validation -> validation.build(statisticsBuilders));
             return Optional.of(new ColumnMetadata<>(statisticsBuilders.build()));
         }
@@ -632,37 +634,37 @@ public class OrcWriteValidation
                 fieldBuilders = ImmutableList.of();
             }
             else if (SMALLINT.equals(type)) {
-                statisticsBuilder = new IntegerStatisticsBuilder();
+                statisticsBuilder = new IntegerStatisticsBuilder(new NoOpBloomFilterBuilder());
                 fieldExtractor = ignored -> ImmutableList.of();
                 fieldBuilders = ImmutableList.of();
             }
             else if (INTEGER.equals(type)) {
-                statisticsBuilder = new IntegerStatisticsBuilder();
+                statisticsBuilder = new IntegerStatisticsBuilder(new NoOpBloomFilterBuilder());
                 fieldExtractor = ignored -> ImmutableList.of();
                 fieldBuilders = ImmutableList.of();
             }
             else if (BIGINT.equals(type)) {
-                statisticsBuilder = new IntegerStatisticsBuilder();
+                statisticsBuilder = new IntegerStatisticsBuilder(new NoOpBloomFilterBuilder());
                 fieldExtractor = ignored -> ImmutableList.of();
                 fieldBuilders = ImmutableList.of();
             }
             else if (DOUBLE.equals(type)) {
-                statisticsBuilder = new DoubleStatisticsBuilder();
+                statisticsBuilder = new DoubleStatisticsBuilder(new NoOpBloomFilterBuilder());
                 fieldExtractor = ignored -> ImmutableList.of();
                 fieldBuilders = ImmutableList.of();
             }
             else if (REAL.equals(type)) {
-                statisticsBuilder = new DoubleStatisticsBuilder();
+                statisticsBuilder = new DoubleStatisticsBuilder(new NoOpBloomFilterBuilder());
                 fieldExtractor = ignored -> ImmutableList.of();
                 fieldBuilders = ImmutableList.of();
             }
             else if (type instanceof VarcharType) {
-                statisticsBuilder = new StringStatisticsBuilder(stringStatisticsLimitInBytes);
+                statisticsBuilder = new StringStatisticsBuilder(stringStatisticsLimitInBytes, new NoOpBloomFilterBuilder());
                 fieldExtractor = ignored -> ImmutableList.of();
                 fieldBuilders = ImmutableList.of();
             }
             else if (type instanceof CharType) {
-                statisticsBuilder = new StringStatisticsBuilder(stringStatisticsLimitInBytes);
+                statisticsBuilder = new StringStatisticsBuilder(stringStatisticsLimitInBytes, new NoOpBloomFilterBuilder());
                 fieldExtractor = ignored -> ImmutableList.of();
                 fieldBuilders = ImmutableList.of();
             }
@@ -672,12 +674,12 @@ public class OrcWriteValidation
                 fieldBuilders = ImmutableList.of();
             }
             else if (DATE.equals(type)) {
-                statisticsBuilder = new DateStatisticsBuilder();
+                statisticsBuilder = new DateStatisticsBuilder(new NoOpBloomFilterBuilder());
                 fieldExtractor = ignored -> ImmutableList.of();
                 fieldBuilders = ImmutableList.of();
             }
             else if (TIMESTAMP.equals(type)) {
-                statisticsBuilder = new CountStatisticsBuilder();
+                statisticsBuilder = new TimestampStatisticsBuilder(new NoOpBloomFilterBuilder());
                 fieldExtractor = ignored -> ImmutableList.of();
                 fieldBuilders = ImmutableList.of();
             }
@@ -761,7 +763,7 @@ public class OrcWriteValidation
         @Override
         public ColumnStatistics buildColumnStatistics()
         {
-            return new ColumnStatistics(rowCount, 0, null, null, null, null, null, null, null, null);
+            return new ColumnStatistics(rowCount, 0, null, null, null, null, null, null, null, null, null);
         }
     }
 

--- a/presto-orc/src/main/java/io/prestosql/orc/OrcWriterOptions.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/OrcWriterOptions.java
@@ -11,10 +11,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.prestosql.orc;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.units.DataSize;
+
+import java.util.Set;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -30,6 +34,8 @@ public class OrcWriterOptions
     private static final int DEFAULT_STRIPE_MAX_ROW_COUNT = 10_000_000;
     private static final int DEFAULT_ROW_GROUP_MAX_ROW_COUNT = 10_000;
     private static final DataSize DEFAULT_DICTIONARY_MAX_MEMORY = new DataSize(16, MEGABYTE);
+    private static final double DEFAULT_BLOOM_FILTER_FPP = 0.05;
+    private static final int BASE_INDEX = 0;
 
     @VisibleForTesting
     static final DataSize DEFAULT_MAX_STRING_STATISTICS_LIMIT = new DataSize(64, BYTE);
@@ -44,6 +50,9 @@ public class OrcWriterOptions
     private final DataSize dictionaryMaxMemory;
     private final DataSize maxStringStatisticsLimit;
     private final DataSize maxCompressionBufferSize;
+    private Set<String> bloomFilterColumns;
+    private final double bloomFilterFpp;
+    private final int baseIndex;
 
     public OrcWriterOptions()
     {
@@ -54,7 +63,10 @@ public class OrcWriterOptions
                 DEFAULT_ROW_GROUP_MAX_ROW_COUNT,
                 DEFAULT_DICTIONARY_MAX_MEMORY,
                 DEFAULT_MAX_STRING_STATISTICS_LIMIT,
-                DEFAULT_MAX_COMPRESSION_BUFFER_SIZE);
+                DEFAULT_MAX_COMPRESSION_BUFFER_SIZE,
+                ImmutableSet.of(),
+                DEFAULT_BLOOM_FILTER_FPP,
+                BASE_INDEX);
     }
 
     private OrcWriterOptions(
@@ -64,7 +76,10 @@ public class OrcWriterOptions
             int rowGroupMaxRowCount,
             DataSize dictionaryMaxMemory,
             DataSize maxStringStatisticsLimit,
-            DataSize maxCompressionBufferSize)
+            DataSize maxCompressionBufferSize,
+            Set<String> bloomFilterColumns,
+            double bloomFilterFpp,
+            int baseIndex)
     {
         requireNonNull(stripeMinSize, "stripeMinSize is null");
         requireNonNull(stripeMaxSize, "stripeMaxSize is null");
@@ -73,6 +88,8 @@ public class OrcWriterOptions
         requireNonNull(dictionaryMaxMemory, "dictionaryMaxMemory is null");
         requireNonNull(maxStringStatisticsLimit, "maxStringStatisticsLimit is null");
         requireNonNull(maxCompressionBufferSize, "maxCompressionBufferSize is null");
+        requireNonNull(bloomFilterColumns, "bloomFilterColumns is null");
+        checkArgument(bloomFilterFpp > 0.0 && bloomFilterFpp < 1.0, "bloomFilterFpp should be > 0.0 & < 1.0");
 
         this.stripeMinSize = stripeMinSize;
         this.stripeMaxSize = stripeMaxSize;
@@ -81,6 +98,9 @@ public class OrcWriterOptions
         this.dictionaryMaxMemory = dictionaryMaxMemory;
         this.maxStringStatisticsLimit = maxStringStatisticsLimit;
         this.maxCompressionBufferSize = maxCompressionBufferSize;
+        this.bloomFilterColumns = ImmutableSet.copyOf(bloomFilterColumns);
+        this.bloomFilterFpp = bloomFilterFpp;
+        this.baseIndex = baseIndex;
     }
 
     public DataSize getStripeMinSize()
@@ -118,39 +138,74 @@ public class OrcWriterOptions
         return maxCompressionBufferSize;
     }
 
+    public boolean isBloomFilterColumn(String columnName)
+    {
+        for (String bloomFilterColumn : bloomFilterColumns) {
+            if (bloomFilterColumn.equals(columnName) || columnName.startsWith(bloomFilterColumn + ".")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public OrcWriterOptions withStripeMinSize(DataSize stripeMinSize)
     {
-        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
+        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize, bloomFilterColumns, bloomFilterFpp, baseIndex);
     }
 
     public OrcWriterOptions withStripeMaxSize(DataSize stripeMaxSize)
     {
-        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
+        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize, bloomFilterColumns, bloomFilterFpp, baseIndex);
     }
 
     public OrcWriterOptions withStripeMaxRowCount(int stripeMaxRowCount)
     {
-        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
+        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize, bloomFilterColumns, bloomFilterFpp, baseIndex);
     }
 
     public OrcWriterOptions withRowGroupMaxRowCount(int rowGroupMaxRowCount)
     {
-        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
+        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize, bloomFilterColumns, bloomFilterFpp, baseIndex);
     }
 
     public OrcWriterOptions withDictionaryMaxMemory(DataSize dictionaryMaxMemory)
     {
-        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
+        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize, bloomFilterColumns, bloomFilterFpp, baseIndex);
     }
 
     public OrcWriterOptions withMaxStringStatisticsLimit(DataSize maxStringStatisticsLimit)
     {
-        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
+        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize, bloomFilterColumns, bloomFilterFpp, baseIndex);
     }
 
     public OrcWriterOptions withMaxCompressionBufferSize(DataSize maxCompressionBufferSize)
     {
-        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
+        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize, bloomFilterColumns, bloomFilterFpp, baseIndex);
+    }
+
+    public OrcWriterOptions withBloomFilterColumns(Set<String> bloomFilterColumns)
+    {
+        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize, bloomFilterColumns, bloomFilterFpp, baseIndex);
+    }
+
+    public OrcWriterOptions withBloomFilterFpp(double bloomFilterFpp)
+    {
+        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize, bloomFilterColumns, bloomFilterFpp, baseIndex);
+    }
+
+    public OrcWriterOptions withBaseIndex(int baseIndex)
+    {
+        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize, bloomFilterColumns, bloomFilterFpp, baseIndex);
+    }
+
+    public double getBloomFilterFpp()
+    {
+        return bloomFilterFpp;
+    }
+
+    public int getBaseIndex()
+    {
+        return baseIndex;
     }
 
     @Override
@@ -164,6 +219,9 @@ public class OrcWriterOptions
                 .add("dictionaryMaxMemory", dictionaryMaxMemory)
                 .add("maxStringStatisticsLimit", maxStringStatisticsLimit)
                 .add("maxCompressionBufferSize", maxCompressionBufferSize)
+                .add("bloomFilterColumns", bloomFilterColumns)
+                .add("bloomFilterFpp", bloomFilterFpp)
+                .add("baseIndex", baseIndex)
                 .toString();
     }
 }

--- a/presto-orc/src/main/java/io/prestosql/orc/TupleDomainOrcPredicate.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/TupleDomainOrcPredicate.java
@@ -147,10 +147,7 @@ public class TupleDomainOrcPredicate
         }
 
         // if none of the discrete predicate values are found in the bloom filter, there is no overlap and the section should be skipped
-        if (discreteValues.get().stream().noneMatch(value -> checkInBloomFilter(bloomFilter, value, stripeDomain.getType()))) {
-            return false;
-        }
-        return true;
+        return discreteValues.get().stream().anyMatch(value -> checkInBloomFilter(bloomFilter, value, stripeDomain.getType()));
     }
 
     @VisibleForTesting
@@ -241,6 +238,9 @@ public class TupleDomainOrcPredicate
         }
         else if (type.getTypeSignature().getBase().equals(StandardTypes.DATE) && columnStatistics.getDateStatistics() != null) {
             return createDomain(type, hasNullValue, columnStatistics.getDateStatistics(), value -> (long) value);
+        }
+        else if (type.getTypeSignature().getBase().equals(StandardTypes.TIMESTAMP) && columnStatistics.getTimestampStatistics() != null) {
+            return createDomain(type, hasNullValue, columnStatistics.getTimestampStatistics(), value -> (long) value);
         }
         else if (type.getJavaType() == long.class && columnStatistics.getIntegerStatistics() != null) {
             return createDomain(type, hasNullValue, columnStatistics.getIntegerStatistics());

--- a/presto-orc/src/main/java/io/prestosql/orc/metadata/CompressedMetadataWriter.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/metadata/CompressedMetadataWriter.java
@@ -16,6 +16,7 @@ package io.prestosql.orc.metadata;
 import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.Slice;
 import io.prestosql.orc.OrcOutputBuffer;
+import io.prestosql.spi.util.BloomFilter;
 
 import java.io.IOException;
 import java.util.List;
@@ -51,6 +52,13 @@ public class CompressedMetadataWriter
             throws IOException
     {
         metadataWriter.writeMetadata(buffer, metadata);
+        return getSliceOutput();
+    }
+
+    public Slice writeBloomFilters(List<BloomFilter> bloomFilters)
+            throws IOException
+    {
+        metadataWriter.writeBloomFilters(buffer, bloomFilters);
         return getSliceOutput();
     }
 

--- a/presto-orc/src/main/java/io/prestosql/orc/metadata/MetadataWriter.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/metadata/MetadataWriter.java
@@ -14,6 +14,7 @@
 package io.prestosql.orc.metadata;
 
 import io.airlift.slice.SliceOutput;
+import io.prestosql.spi.util.BloomFilter;
 
 import java.io.IOException;
 import java.util.List;
@@ -35,5 +36,8 @@ public interface MetadataWriter
             throws IOException;
 
     int writeRowIndexes(SliceOutput output, List<RowGroupIndex> rowGroupIndexes)
+            throws IOException;
+
+    int writeBloomFilters(SliceOutput output, List<BloomFilter> bloomFilters)
             throws IOException;
 }

--- a/presto-orc/src/main/java/io/prestosql/orc/metadata/OrcMetadataReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/metadata/OrcMetadataReader.java
@@ -34,6 +34,7 @@ import io.prestosql.orc.metadata.statistics.HashableBloomFilter;
 import io.prestosql.orc.metadata.statistics.IntegerStatistics;
 import io.prestosql.orc.metadata.statistics.StringStatistics;
 import io.prestosql.orc.metadata.statistics.StripeStatistics;
+import io.prestosql.orc.metadata.statistics.TimestampStatistics;
 import io.prestosql.orc.proto.OrcProto;
 import io.prestosql.orc.proto.OrcProto.RowIndexEntry;
 import io.prestosql.orc.protobuf.ByteString;
@@ -70,6 +71,7 @@ import static io.prestosql.orc.metadata.statistics.DoubleStatistics.DOUBLE_VALUE
 import static io.prestosql.orc.metadata.statistics.IntegerStatistics.INTEGER_VALUE_BYTES;
 import static io.prestosql.orc.metadata.statistics.ShortDecimalStatisticsBuilder.SHORT_DECIMAL_VALUE_BYTES;
 import static io.prestosql.orc.metadata.statistics.StringStatistics.STRING_VALUE_BYTES_OVERHEAD;
+import static io.prestosql.orc.metadata.statistics.TimestampStatistics.TIMESTAMP_VALUE_BYTES;
 import static java.lang.Character.MIN_SUPPLEMENTARY_CODE_POINT;
 import static java.lang.Math.toIntExact;
 
@@ -268,6 +270,9 @@ public class OrcMetadataReader
         else if (statistics.hasDateStatistics()) {
             minAverageValueBytes = DATE_VALUE_BYTES;
         }
+        else if (statistics.hasTimestampStatistics()) {
+            minAverageValueBytes = TIMESTAMP_VALUE_BYTES;
+        }
         else if (statistics.hasDecimalStatistics()) {
             // could be 8 or 16; return the smaller one given it is a min average
             minAverageValueBytes = DECIMAL_VALUE_BYTES_OVERHEAD + SHORT_DECIMAL_VALUE_BYTES;
@@ -291,6 +296,7 @@ public class OrcMetadataReader
                 statistics.hasDoubleStatistics() ? toDoubleStatistics(statistics.getDoubleStatistics()) : null,
                 statistics.hasStringStatistics() ? toStringStatistics(hiveWriterVersion, statistics.getStringStatistics(), isRowGroup) : null,
                 statistics.hasDateStatistics() ? toDateStatistics(hiveWriterVersion, statistics.getDateStatistics(), isRowGroup) : null,
+                statistics.hasTimestampStatistics() ? toTimestampStatistics(hiveWriterVersion, statistics.getTimestampStatistics(), isRowGroup) : null,
                 statistics.hasDecimalStatistics() ? toDecimalStatistics(statistics.getDecimalStatistics()) : null,
                 statistics.hasBinaryStatistics() ? toBinaryStatistics(statistics.getBinaryStatistics()) : null,
                 null);
@@ -480,6 +486,17 @@ public class OrcMetadataReader
         return new DateStatistics(
                 dateStatistics.hasMinimum() ? dateStatistics.getMinimum() : null,
                 dateStatistics.hasMaximum() ? dateStatistics.getMaximum() : null);
+    }
+
+    private static TimestampStatistics toTimestampStatistics(HiveWriterVersion hiveWriterVersion, OrcProto.TimestampStatistics timestampStatistics, boolean isRowGroup)
+    {
+        if (hiveWriterVersion == ORIGINAL && !isRowGroup) {
+            return null;
+        }
+
+        return new TimestampStatistics(
+                timestampStatistics.hasMinimumUtc() ? timestampStatistics.getMinimumUtc() : null,
+                timestampStatistics.hasMaximumUtc() ? timestampStatistics.getMaximumUtc() : null);
     }
 
     private static OrcType toType(OrcProto.Type type)

--- a/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/BinaryStatisticsBuilder.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/BinaryStatisticsBuilder.java
@@ -67,6 +67,7 @@ public class BinaryStatisticsBuilder
                 null,
                 null,
                 null,
+                null,
                 binaryStatistics.orElse(null),
                 null);
     }

--- a/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/BloomFilterBuilder.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/BloomFilterBuilder.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2018-2022. Huawei Technologies Co., Ltd. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.prestosql.orc.metadata.statistics;
+
+import io.airlift.slice.Slice;
+
+public interface BloomFilterBuilder
+{
+    BloomFilterBuilder addString(Slice val);
+
+    BloomFilterBuilder addLong(long val);
+
+    BloomFilterBuilder addDouble(double val);
+
+    BloomFilterBuilder addFloat(float val);
+
+    HashableBloomFilter buildBloomFilter();
+}

--- a/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/BooleanStatisticsBuilder.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/BooleanStatisticsBuilder.java
@@ -76,6 +76,7 @@ public class BooleanStatisticsBuilder
                 null,
                 null,
                 null,
+                null,
                 null);
     }
 

--- a/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/ColumnStatistics.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/ColumnStatistics.java
@@ -11,6 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.prestosql.orc.metadata.statistics;
 
 import io.prestosql.orc.metadata.statistics.StatisticsHasher.Hashable;
@@ -27,6 +28,7 @@ import static io.prestosql.orc.metadata.statistics.DoubleStatisticsBuilder.merge
 import static io.prestosql.orc.metadata.statistics.IntegerStatisticsBuilder.mergeIntegerStatistics;
 import static io.prestosql.orc.metadata.statistics.LongDecimalStatisticsBuilder.mergeDecimalStatistics;
 import static io.prestosql.orc.metadata.statistics.StringStatisticsBuilder.mergeStringStatistics;
+import static io.prestosql.orc.metadata.statistics.TimestampStatisticsBuilder.mergeTimestampStatistics;
 
 public class ColumnStatistics
         implements Hashable
@@ -41,6 +43,7 @@ public class ColumnStatistics
     private final DoubleStatistics doubleStatistics;
     private final StringStatistics stringStatistics;
     private final DateStatistics dateStatistics;
+    private final TimestampStatistics timestampStatistics;
     private final DecimalStatistics decimalStatistics;
     private final BinaryStatistics binaryStatistics;
     private final HashableBloomFilter bloomFilter;
@@ -53,6 +56,7 @@ public class ColumnStatistics
             DoubleStatistics doubleStatistics,
             StringStatistics stringStatistics,
             DateStatistics dateStatistics,
+            TimestampStatistics timestampStatistics,
             DecimalStatistics decimalStatistics,
             BinaryStatistics binaryStatistics,
             HashableBloomFilter bloomFilter)
@@ -65,6 +69,7 @@ public class ColumnStatistics
         this.doubleStatistics = doubleStatistics;
         this.stringStatistics = stringStatistics;
         this.dateStatistics = dateStatistics;
+        this.timestampStatistics = timestampStatistics;
         this.decimalStatistics = decimalStatistics;
         this.binaryStatistics = binaryStatistics;
         this.bloomFilter = bloomFilter;
@@ -126,6 +131,11 @@ public class ColumnStatistics
         return decimalStatistics;
     }
 
+    public TimestampStatistics getTimestampStatistics()
+    {
+        return timestampStatistics;
+    }
+
     public BinaryStatistics getBinaryStatistics()
     {
         return binaryStatistics;
@@ -146,6 +156,7 @@ public class ColumnStatistics
                 doubleStatistics,
                 stringStatistics,
                 dateStatistics,
+                timestampStatistics,
                 decimalStatistics,
                 binaryStatistics,
                 bloomFilter);
@@ -168,6 +179,9 @@ public class ColumnStatistics
         }
         if (dateStatistics != null) {
             retainedSizeInBytes += dateStatistics.getRetainedSizeInBytes();
+        }
+        if (timestampStatistics != null) {
+            retainedSizeInBytes += timestampStatistics.getRetainedSizeInBytes();
         }
         if (decimalStatistics != null) {
             retainedSizeInBytes += decimalStatistics.getRetainedSizeInBytes();
@@ -198,6 +212,7 @@ public class ColumnStatistics
                 Objects.equals(doubleStatistics, that.doubleStatistics) &&
                 Objects.equals(stringStatistics, that.stringStatistics) &&
                 Objects.equals(dateStatistics, that.dateStatistics) &&
+                Objects.equals(timestampStatistics, that.timestampStatistics) &&
                 Objects.equals(decimalStatistics, that.decimalStatistics) &&
                 Objects.equals(binaryStatistics, that.binaryStatistics) &&
                 Objects.equals(bloomFilter, that.bloomFilter);
@@ -214,6 +229,7 @@ public class ColumnStatistics
                 doubleStatistics,
                 stringStatistics,
                 dateStatistics,
+                timestampStatistics,
                 decimalStatistics,
                 binaryStatistics,
                 bloomFilter);
@@ -230,6 +246,7 @@ public class ColumnStatistics
                 .add("doubleStatistics", doubleStatistics)
                 .add("stringStatistics", stringStatistics)
                 .add("dateStatistics", dateStatistics)
+                .add("timestampStatistics", timestampStatistics)
                 .add("decimalStatistics", decimalStatistics)
                 .add("binaryStatistics", binaryStatistics)
                 .add("bloomFilter", bloomFilter)
@@ -245,6 +262,7 @@ public class ColumnStatistics
                 .putOptionalHashable(doubleStatistics)
                 .putOptionalHashable(stringStatistics)
                 .putOptionalHashable(dateStatistics)
+                .putOptionalHashable(timestampStatistics)
                 .putOptionalHashable(decimalStatistics)
                 .putOptionalHashable(binaryStatistics)
                 .putOptionalHashable(bloomFilter);
@@ -271,6 +289,7 @@ public class ColumnStatistics
                 mergeDoubleStatistics(stats).orElse(null),
                 mergeStringStatistics(stats).orElse(null),
                 mergeDateStatistics(stats).orElse(null),
+                mergeTimestampStatistics(stats).orElse(null),
                 mergeDecimalStatistics(stats).orElse(null),
                 mergeBinaryStatistics(stats).orElse(null),
                 null);

--- a/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/DoubleStatisticsBuilder.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/DoubleStatisticsBuilder.java
@@ -31,6 +31,13 @@ public class DoubleStatisticsBuilder
     private double minimum = Double.POSITIVE_INFINITY;
     private double maximum = Double.NEGATIVE_INFINITY;
 
+    private final BloomFilterBuilder bloomFilterBuilder;
+
+    public DoubleStatisticsBuilder(BloomFilterBuilder bloomFilterBuilder)
+    {
+        this.bloomFilterBuilder = requireNonNull(bloomFilterBuilder, "bloomFilterBuilder is null");
+    }
+
     @Override
     public void addBlock(Type type, Block block)
     {
@@ -58,6 +65,7 @@ public class DoubleStatisticsBuilder
             minimum = Math.min(value, minimum);
             maximum = Math.max(value, maximum);
         }
+        bloomFilterBuilder.addDouble(value);
     }
 
     private void addDoubleStatistics(long valueCount, DoubleStatistics value)
@@ -94,12 +102,13 @@ public class DoubleStatisticsBuilder
                 null,
                 null,
                 null,
-                null);
+                null,
+                bloomFilterBuilder.buildBloomFilter());
     }
 
     public static Optional<DoubleStatistics> mergeDoubleStatistics(List<ColumnStatistics> stats)
     {
-        DoubleStatisticsBuilder doubleStatisticsBuilder = new DoubleStatisticsBuilder();
+        DoubleStatisticsBuilder doubleStatisticsBuilder = new DoubleStatisticsBuilder(new NoOpBloomFilterBuilder());
         for (ColumnStatistics columnStatistics : stats) {
             DoubleStatistics partialStatistics = columnStatistics.getDoubleStatistics();
             if (columnStatistics.getNumberOfValues() > 0) {

--- a/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/IntegerStatisticsBuilder.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/IntegerStatisticsBuilder.java
@@ -28,6 +28,12 @@ public class IntegerStatisticsBuilder
     private long maximum = Long.MIN_VALUE;
     private long sum;
     private boolean overflow;
+    private final BloomFilterBuilder bloomFilterBuilder;
+
+    public IntegerStatisticsBuilder(BloomFilterBuilder bloomFilterBuilder)
+    {
+        this.bloomFilterBuilder = requireNonNull(bloomFilterBuilder, "bloomFilterBuilder is null");
+    }
 
     @Override
     public void addValue(long value)
@@ -45,6 +51,7 @@ public class IntegerStatisticsBuilder
                 overflow = true;
             }
         }
+        bloomFilterBuilder.addLong(value);
     }
 
     private void addIntegerStatistics(long valueCount, IntegerStatistics value)
@@ -95,17 +102,18 @@ public class IntegerStatisticsBuilder
                 null,
                 null,
                 null,
-                null);
+                null,
+                bloomFilterBuilder.buildBloomFilter());
     }
 
     public static Optional<IntegerStatistics> mergeIntegerStatistics(List<ColumnStatistics> stats)
     {
-        IntegerStatisticsBuilder integerStatisticsBuilder = new IntegerStatisticsBuilder();
+        IntegerStatisticsBuilder integerStatisticsBuilder = new IntegerStatisticsBuilder(new NoOpBloomFilterBuilder());
         for (ColumnStatistics columnStatistics : stats) {
             IntegerStatistics partialStatistics = columnStatistics.getIntegerStatistics();
             if (columnStatistics.getNumberOfValues() > 0) {
                 if (partialStatistics == null) {
-                    // there are non null values but no statistics, so we can not say anything about the data
+                    // there are non-null values but no statistics, so we can not say anything about the data
                     return Optional.empty();
                 }
                 integerStatisticsBuilder.addIntegerStatistics(columnStatistics.getNumberOfValues(), partialStatistics);

--- a/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/LongDecimalStatisticsBuilder.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/LongDecimalStatisticsBuilder.java
@@ -102,6 +102,7 @@ public class LongDecimalStatisticsBuilder
                 null,
                 null,
                 null,
+                null,
                 decimalStatistics.orElse(null),
                 null,
                 null);

--- a/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/NoOpBloomFilterBuilder.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/NoOpBloomFilterBuilder.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2018-2022. Huawei Technologies Co., Ltd. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.prestosql.orc.metadata.statistics;
+
+import io.airlift.slice.Slice;
+
+public class NoOpBloomFilterBuilder
+        implements BloomFilterBuilder
+{
+    @Override
+    public BloomFilterBuilder addString(Slice val)
+    {
+        return this;
+    }
+
+    @Override
+    public BloomFilterBuilder addLong(long val)
+    {
+        return this;
+    }
+
+    @Override
+    public BloomFilterBuilder addDouble(double val)
+    {
+        return this;
+    }
+
+    @Override
+    public BloomFilterBuilder addFloat(float val)
+    {
+        return this;
+    }
+
+    @Override
+    public HashableBloomFilter buildBloomFilter()
+    {
+        return null;
+    }
+}

--- a/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/ShortDecimalStatisticsBuilder.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/ShortDecimalStatisticsBuilder.java
@@ -67,6 +67,7 @@ public class ShortDecimalStatisticsBuilder
                 null,
                 null,
                 null,
+                null,
                 decimalStatistics.orElse(null),
                 null,
                 null);

--- a/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/StringStatisticsBuilder.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/StringStatisticsBuilder.java
@@ -35,25 +35,27 @@ public class StringStatisticsBuilder
     private Slice minimum;
     private Slice maximum;
     private long sum;
+    private final BloomFilterBuilder bloomFilterBuilder;
 
-    public StringStatisticsBuilder(int stringStatisticsLimitInBytes)
+    public StringStatisticsBuilder(int stringStatisticsLimitInBytes, BloomFilterBuilder bloomFilterBuilder)
     {
-        this(stringStatisticsLimitInBytes, 0, null, null, 0);
+        this(stringStatisticsLimitInBytes, 0, null, null, 0, bloomFilterBuilder);
     }
 
-    private StringStatisticsBuilder(int stringStatisticsLimitInBytes, long nonNullValueCount, Slice minimum, Slice maximum, long sum)
+    private StringStatisticsBuilder(int stringStatisticsLimitInBytes, long nonNullValueCount, Slice minimum, Slice maximum, long sum, BloomFilterBuilder bloomFilterBuilder)
     {
         this.stringStatisticsLimitInBytes = stringStatisticsLimitInBytes;
         this.nonNullValueCount = nonNullValueCount;
         this.minimum = minimum;
         this.maximum = maximum;
         this.sum = sum;
+        this.bloomFilterBuilder = requireNonNull(bloomFilterBuilder, "bloomFilterBuilder is null");
     }
 
     public StringStatisticsBuilder withStringStatisticsLimit(int limitInBytes)
     {
         checkArgument(limitInBytes >= 0, "limitInBytes is less than 0");
-        return new StringStatisticsBuilder(limitInBytes, nonNullValueCount, minimum, maximum, sum);
+        return new StringStatisticsBuilder(limitInBytes, nonNullValueCount, minimum, maximum, sum, bloomFilterBuilder);
     }
 
     public long getNonNullValueCount()
@@ -77,7 +79,7 @@ public class StringStatisticsBuilder
         else if (maximum != null && value.compareTo(maximum) >= 0) {
             maximum = value;
         }
-
+        bloomFilterBuilder.addString(value);
         nonNullValueCount++;
         sum = addExact(sum, value.length());
     }
@@ -140,18 +142,19 @@ public class StringStatisticsBuilder
                 null,
                 null,
                 null,
-                null);
+                null,
+                bloomFilterBuilder.buildBloomFilter());
     }
 
     public static Optional<StringStatistics> mergeStringStatistics(List<ColumnStatistics> stats)
     {
         // no need to set the stats limit for the builder given we assume the given stats are within the same limit
-        StringStatisticsBuilder stringStatisticsBuilder = new StringStatisticsBuilder(Integer.MAX_VALUE);
+        StringStatisticsBuilder stringStatisticsBuilder = new StringStatisticsBuilder(Integer.MAX_VALUE, new NoOpBloomFilterBuilder());
         for (ColumnStatistics columnStatistics : stats) {
             StringStatistics partialStatistics = columnStatistics.getStringStatistics();
             if (columnStatistics.getNumberOfValues() > 0) {
                 if (partialStatistics == null || (partialStatistics.getMin() == null && partialStatistics.getMax() == null)) {
-                    // there are non null values but no statistics, so we can not say anything about the data
+                    // there are non-null values but no statistics, so we can not say anything about the data
                     return Optional.empty();
                 }
                 stringStatisticsBuilder.addStringStatistics(columnStatistics.getNumberOfValues(), partialStatistics);

--- a/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/TimestampStatistics.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/TimestampStatistics.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2018-2022. Huawei Technologies Co., Ltd. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.prestosql.orc.metadata.statistics;
+
+import io.prestosql.orc.metadata.statistics.StatisticsHasher.Hashable;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class TimestampStatistics
+        implements RangeStatistics<Long>, Hashable
+{
+    // 1 byte to denote if null + 8 bytes for the value (timestamp is of long type)
+    public static final long TIMESTAMP_VALUE_BYTES = Byte.BYTES + Long.BYTES;
+
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(TimestampStatistics.class).instanceSize();
+
+    private final boolean hasMinimum;
+    private final boolean hasMaximum;
+
+    private final long minimum;
+    private final long maximum;
+
+    public TimestampStatistics(Long minimum, Long maximum)
+    {
+        checkArgument(minimum == null || maximum == null || minimum <= maximum, "minimum is not less than maximum");
+
+        this.hasMinimum = minimum != null;
+        this.minimum = hasMinimum ? minimum : 0;
+
+        this.hasMaximum = maximum != null;
+        this.maximum = hasMaximum ? maximum : 0;
+    }
+
+    @Override
+    public Long getMin()
+    {
+        return hasMinimum ? minimum : null;
+    }
+
+    @Override
+    public Long getMax()
+    {
+        return hasMaximum ? maximum : null;
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TimestampStatistics that = (TimestampStatistics) o;
+        return Objects.equals(getMin(), that.getMin()) &&
+                Objects.equals(getMax(), that.getMax());
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(getMin(), getMax());
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("min", getMin())
+                .add("max", getMax())
+                .toString();
+    }
+
+    @Override
+    public void addHash(StatisticsHasher hasher)
+    {
+        hasher.putOptionalLong(hasMinimum, minimum)
+                .putOptionalLong(hasMaximum, maximum);
+    }
+}

--- a/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/Utf8BloomFilterBuilder.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/Utf8BloomFilterBuilder.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2018-2022. Huawei Technologies Co., Ltd. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.prestosql.orc.metadata.statistics;
+
+import io.airlift.slice.Slice;
+
+public class Utf8BloomFilterBuilder
+        implements BloomFilterBuilder
+{
+    private final HashableBloomFilter bloomFilter;
+
+    public Utf8BloomFilterBuilder(int expectedSize, double fpp)
+    {
+        bloomFilter = new HashableBloomFilter(expectedSize, fpp);
+    }
+
+    @Override
+    public BloomFilterBuilder addString(Slice val)
+    {
+        bloomFilter.add(val);
+        return this;
+    }
+
+    @Override
+    public BloomFilterBuilder addLong(long val)
+    {
+        bloomFilter.addLong(val);
+        return this;
+    }
+
+    @Override
+    public BloomFilterBuilder addDouble(double val)
+    {
+        bloomFilter.addDouble(val);
+        return this;
+    }
+
+    @Override
+    public BloomFilterBuilder addFloat(float val)
+    {
+        bloomFilter.addFloat(val);
+        return this;
+    }
+
+    @Override
+    public HashableBloomFilter buildBloomFilter()
+    {
+        return bloomFilter;
+    }
+}

--- a/presto-orc/src/main/java/io/prestosql/orc/writer/BooleanColumnWriter.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/writer/BooleanColumnWriter.java
@@ -167,6 +167,12 @@ public class BooleanColumnWriter
     }
 
     @Override
+    public List<StreamDataOutput> getBloomFilters(CompressedMetadataWriter metadataWriter)
+    {
+        return ImmutableList.of();
+    }
+
+    @Override
     public List<StreamDataOutput> getDataStreams()
     {
         checkState(closed);

--- a/presto-orc/src/main/java/io/prestosql/orc/writer/ByteColumnWriter.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/writer/ByteColumnWriter.java
@@ -32,16 +32,19 @@ import io.prestosql.orc.stream.PresentOutputStream;
 import io.prestosql.orc.stream.StreamDataOutput;
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.type.Type;
+import io.prestosql.spi.util.BloomFilter;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.prestosql.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT;
 import static io.prestosql.orc.metadata.CompressionKind.NONE;
 import static java.util.Objects.requireNonNull;
@@ -110,7 +113,7 @@ public class ByteColumnWriter
     public Map<OrcColumnId, ColumnStatistics> finishRowGroup()
     {
         checkState(!closed);
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null, null);
         rowGroupColumnStatistics.add(statistics);
         nonNullValueCount = 0;
         return ImmutableMap.of(columnId, statistics);
@@ -164,6 +167,24 @@ public class ByteColumnWriter
         presentCheckpoint.ifPresent(booleanStreamCheckpoint -> positionList.addAll(booleanStreamCheckpoint.toPositionList(compressed)));
         positionList.addAll(dataCheckpoint.toPositionList(compressed));
         return positionList.build();
+    }
+
+    @Override
+    public List<StreamDataOutput> getBloomFilters(CompressedMetadataWriter metadataWriter)
+            throws IOException
+    {
+        List<BloomFilter> bloomFilters = rowGroupColumnStatistics.stream()
+                .map(ColumnStatistics::getBloomFilter)
+                .filter(Objects::nonNull)
+                .collect(toImmutableList());
+
+        if (!bloomFilters.isEmpty()) {
+            Slice slice = metadataWriter.writeBloomFilters(bloomFilters);
+            Stream stream = new Stream(columnId, StreamKind.BLOOM_FILTER_UTF8, slice.length(), false);
+            return ImmutableList.of(new StreamDataOutput(slice, stream));
+        }
+
+        return ImmutableList.of();
     }
 
     @Override

--- a/presto-orc/src/main/java/io/prestosql/orc/writer/ColumnWriter.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/writer/ColumnWriter.java
@@ -66,4 +66,7 @@ public interface ColumnWriter
     long getRetainedBytes();
 
     void reset();
+
+    List<StreamDataOutput> getBloomFilters(CompressedMetadataWriter metadataWriter)
+            throws IOException;
 }

--- a/presto-orc/src/main/java/io/prestosql/orc/writer/ColumnWriters.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/writer/ColumnWriters.java
@@ -11,23 +11,36 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.prestosql.orc.writer;
 
 import com.google.common.collect.ImmutableList;
 import io.airlift.units.DataSize;
+import io.prestosql.orc.OrcWriterOptions;
 import io.prestosql.orc.metadata.ColumnMetadata;
 import io.prestosql.orc.metadata.CompressionKind;
 import io.prestosql.orc.metadata.OrcColumnId;
 import io.prestosql.orc.metadata.OrcType;
 import io.prestosql.orc.metadata.statistics.BinaryStatisticsBuilder;
+import io.prestosql.orc.metadata.statistics.BloomFilterBuilder;
 import io.prestosql.orc.metadata.statistics.DateStatisticsBuilder;
+import io.prestosql.orc.metadata.statistics.DoubleStatisticsBuilder;
 import io.prestosql.orc.metadata.statistics.IntegerStatisticsBuilder;
+import io.prestosql.orc.metadata.statistics.NoOpBloomFilterBuilder;
+import io.prestosql.orc.metadata.statistics.StringStatisticsBuilder;
+import io.prestosql.orc.metadata.statistics.TimestampStatisticsBuilder;
+import io.prestosql.orc.metadata.statistics.Utf8BloomFilterBuilder;
 import io.prestosql.spi.type.Type;
 
+import java.util.function.Supplier;
+
+import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public final class ColumnWriters
 {
+    private static final int BASE_OFFSET_FOR_TRANSACTIONAL_TABLE = 6;
+
     private ColumnWriters() {}
 
     public static ColumnWriter createColumnWriter(
@@ -36,36 +49,40 @@ public final class ColumnWriters
             Type type,
             CompressionKind compression,
             int bufferSize,
-            DataSize stringStatisticsLimit)
+            OrcWriterOptions options,
+            String columnName,
+            Supplier<BloomFilterBuilder> bloomFilterBuilder)
     {
         requireNonNull(type, "type is null");
         OrcType orcType = orcTypes.get(columnId);
+        DataSize stringStatisticsLimit = options.getMaxStringStatisticsLimit();
+
         switch (orcType.getOrcTypeKind()) {
             case BOOLEAN:
                 return new BooleanColumnWriter(columnId, type, compression, bufferSize);
 
             case FLOAT:
-                return new FloatColumnWriter(columnId, type, compression, bufferSize);
+                return new FloatColumnWriter(columnId, type, compression, bufferSize, () -> new DoubleStatisticsBuilder(bloomFilterBuilder.get()));
 
             case DOUBLE:
-                return new DoubleColumnWriter(columnId, type, compression, bufferSize);
+                return new DoubleColumnWriter(columnId, type, compression, bufferSize, () -> new DoubleStatisticsBuilder(bloomFilterBuilder.get()));
 
             case BYTE:
                 return new ByteColumnWriter(columnId, type, compression, bufferSize);
 
             case DATE:
-                return new LongColumnWriter(columnId, type, compression, bufferSize, DateStatisticsBuilder::new);
+                return new LongColumnWriter(columnId, type, compression, bufferSize, () -> new DateStatisticsBuilder(bloomFilterBuilder.get()));
 
             case SHORT:
             case INT:
             case LONG:
-                return new LongColumnWriter(columnId, type, compression, bufferSize, IntegerStatisticsBuilder::new);
+                return new LongColumnWriter(columnId, type, compression, bufferSize, () -> new IntegerStatisticsBuilder(bloomFilterBuilder.get()));
 
             case DECIMAL:
                 return new DecimalColumnWriter(columnId, type, compression, bufferSize);
 
             case TIMESTAMP:
-                return new TimestampColumnWriter(columnId, type, compression, bufferSize);
+                return new TimestampColumnWriter(columnId, type, compression, bufferSize, () -> new TimestampStatisticsBuilder(bloomFilterBuilder.get()));
 
             case BINARY:
                 return new SliceDirectColumnWriter(columnId, type, compression, bufferSize, BinaryStatisticsBuilder::new);
@@ -73,12 +90,12 @@ public final class ColumnWriters
             case CHAR:
             case VARCHAR:
             case STRING:
-                return new SliceDictionaryColumnWriter(columnId, type, compression, bufferSize, stringStatisticsLimit);
+                return new SliceDictionaryColumnWriter(columnId, type, compression, bufferSize, () -> new StringStatisticsBuilder(toIntExact(stringStatisticsLimit.toBytes()), bloomFilterBuilder.get()));
 
             case LIST: {
                 OrcColumnId fieldColumnIndex = orcType.getFieldTypeIndex(0);
                 Type fieldType = type.getTypeParameters().get(0);
-                ColumnWriter elementWriter = createColumnWriter(fieldColumnIndex, orcTypes, fieldType, compression, bufferSize, stringStatisticsLimit);
+                ColumnWriter elementWriter = createColumnWriter(fieldColumnIndex, orcTypes, fieldType, compression, bufferSize, options, columnName, bloomFilterBuilder);
                 return new ListColumnWriter(columnId, compression, bufferSize, elementWriter);
             }
 
@@ -89,14 +106,18 @@ public final class ColumnWriters
                         type.getTypeParameters().get(0),
                         compression,
                         bufferSize,
-                        stringStatisticsLimit);
+                        options,
+                        columnName,
+                        bloomFilterBuilder);
                 ColumnWriter valueWriter = createColumnWriter(
                         orcType.getFieldTypeIndex(1),
                         orcTypes,
                         type.getTypeParameters().get(1),
                         compression,
                         bufferSize,
-                        stringStatisticsLimit);
+                        options,
+                        columnName,
+                        bloomFilterBuilder);
                 return new MapColumnWriter(columnId, compression, bufferSize, keyWriter, valueWriter);
             }
 
@@ -105,12 +126,33 @@ public final class ColumnWriters
                 for (int fieldId = 0; fieldId < orcType.getFieldCount(); fieldId++) {
                     OrcColumnId fieldColumnIndex = orcType.getFieldTypeIndex(fieldId);
                     Type fieldType = type.getTypeParameters().get(fieldId);
-                    fieldWriters.add(createColumnWriter(fieldColumnIndex, orcTypes, fieldType, compression, bufferSize, stringStatisticsLimit));
+                    String colName = isTransactional(options) && columnId.getId() == BASE_OFFSET_FOR_TRANSACTIONAL_TABLE ? orcType.getFieldName(fieldId) : columnName + "." + orcType.getFieldName(fieldId);
+                    fieldWriters.add(createColumnWriter(fieldColumnIndex,
+                            orcTypes,
+                            fieldType,
+                            compression,
+                            bufferSize,
+                            options,
+                            colName,
+                            getBloomFilterBuilder(options, colName, fieldColumnIndex.getId())));
                 }
                 return new StructColumnWriter(columnId, compression, bufferSize, fieldWriters.build());
             }
         }
 
         throw new IllegalArgumentException("Unsupported type: " + type);
+    }
+
+    public static Supplier<BloomFilterBuilder> getBloomFilterBuilder(OrcWriterOptions options, String columnName, Integer columnId)
+    {
+        if (columnId > options.getBaseIndex() && options.isBloomFilterColumn(columnName)) {
+            return () -> new Utf8BloomFilterBuilder(options.getRowGroupMaxRowCount(), options.getBloomFilterFpp());
+        }
+        return NoOpBloomFilterBuilder::new;
+    }
+
+    public static boolean isTransactional(OrcWriterOptions options)
+    {
+        return options.getBaseIndex() == 0 ? false : true;
     }
 }

--- a/presto-orc/src/main/java/io/prestosql/orc/writer/DecimalColumnWriter.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/writer/DecimalColumnWriter.java
@@ -254,4 +254,11 @@ public class DecimalColumnWriter
         shortDecimalStatisticsBuilder = new ShortDecimalStatisticsBuilder(this.type.getScale());
         longDecimalStatisticsBuilder = new LongDecimalStatisticsBuilder();
     }
+
+    @Override
+    public List<StreamDataOutput> getBloomFilters(CompressedMetadataWriter metadataWriter)
+            throws IOException
+    {
+        return ImmutableList.of();
+    }
 }

--- a/presto-orc/src/main/java/io/prestosql/orc/writer/DoubleColumnWriter.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/writer/DoubleColumnWriter.java
@@ -32,16 +32,20 @@ import io.prestosql.orc.stream.PresentOutputStream;
 import io.prestosql.orc.stream.StreamDataOutput;
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.type.Type;
+import io.prestosql.spi.util.BloomFilter;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.prestosql.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT;
 import static io.prestosql.orc.metadata.CompressionKind.NONE;
 import static java.util.Objects.requireNonNull;
@@ -59,18 +63,20 @@ public class DoubleColumnWriter
     private final PresentOutputStream presentStream;
 
     private final List<ColumnStatistics> rowGroupColumnStatistics = new ArrayList<>();
-
-    private DoubleStatisticsBuilder statisticsBuilder = new DoubleStatisticsBuilder();
+    private final Supplier<DoubleStatisticsBuilder> statisticsBuilderSupplier;
+    private DoubleStatisticsBuilder statisticsBuilder;
 
     private boolean closed;
 
-    public DoubleColumnWriter(OrcColumnId columnId, Type type, CompressionKind compression, int bufferSize)
+    public DoubleColumnWriter(OrcColumnId columnId, Type type, CompressionKind compression, int bufferSize, Supplier<DoubleStatisticsBuilder> statisticsBuilderSupplier)
     {
         this.columnId = requireNonNull(columnId, "columnId is null");
         this.type = requireNonNull(type, "type is null");
         this.compressed = requireNonNull(compression, "compression is null") != NONE;
         this.dataStream = new DoubleOutputStream(compression, bufferSize);
         this.presentStream = new PresentOutputStream(compression, bufferSize);
+        this.statisticsBuilderSupplier = requireNonNull(statisticsBuilderSupplier, "statisticsBuilderSupplier is null");
+        this.statisticsBuilder = statisticsBuilderSupplier.get();
     }
 
     @Override
@@ -113,7 +119,7 @@ public class DoubleColumnWriter
         checkState(!closed);
         ColumnStatistics statistics = statisticsBuilder.buildColumnStatistics();
         rowGroupColumnStatistics.add(statistics);
-        statisticsBuilder = new DoubleStatisticsBuilder();
+        statisticsBuilder = statisticsBuilderSupplier.get();
         return ImmutableMap.of(columnId, statistics);
     }
 
@@ -154,6 +160,24 @@ public class DoubleColumnWriter
         Slice slice = metadataWriter.writeRowIndexes(rowGroupIndexes.build());
         Stream stream = new Stream(columnId, StreamKind.ROW_INDEX, slice.length(), false);
         return ImmutableList.of(new StreamDataOutput(slice, stream));
+    }
+
+    @Override
+    public List<StreamDataOutput> getBloomFilters(CompressedMetadataWriter metadataWriter)
+            throws IOException
+    {
+        List<BloomFilter> bloomFilters = rowGroupColumnStatistics.stream()
+                .map(ColumnStatistics::getBloomFilter)
+                .filter(Objects::nonNull)
+                .collect(toImmutableList());
+
+        if (!bloomFilters.isEmpty()) {
+            Slice slice = metadataWriter.writeBloomFilters(bloomFilters);
+            Stream stream = new Stream(columnId, StreamKind.BLOOM_FILTER_UTF8, slice.length(), false);
+            return ImmutableList.of(new StreamDataOutput(slice, stream));
+        }
+
+        return ImmutableList.of();
     }
 
     private static List<Integer> createDoubleColumnPositionList(
@@ -201,6 +225,6 @@ public class DoubleColumnWriter
         dataStream.reset();
         presentStream.reset();
         rowGroupColumnStatistics.clear();
-        statisticsBuilder = new DoubleStatisticsBuilder();
+        statisticsBuilder = statisticsBuilderSupplier.get();
     }
 }

--- a/presto-orc/src/main/java/io/prestosql/orc/writer/ListColumnWriter.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/writer/ListColumnWriter.java
@@ -135,7 +135,7 @@ public class ListColumnWriter
     {
         checkState(!closed);
 
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null, null);
         rowGroupColumnStatistics.add(statistics);
         nonNullValueCount = 0;
 
@@ -189,6 +189,7 @@ public class ListColumnWriter
         ImmutableList.Builder<StreamDataOutput> indexStreams = ImmutableList.builder();
         indexStreams.add(new StreamDataOutput(slice, stream));
         indexStreams.addAll(elementWriter.getIndexStreams(metadataWriter));
+        indexStreams.addAll(elementWriter.getBloomFilters(metadataWriter));
         return indexStreams.build();
     }
 
@@ -240,5 +241,12 @@ public class ListColumnWriter
         elementWriter.reset();
         rowGroupColumnStatistics.clear();
         nonNullValueCount = 0;
+    }
+
+    @Override
+    public List<StreamDataOutput> getBloomFilters(CompressedMetadataWriter metadataWriter)
+            throws IOException
+    {
+        return ImmutableList.of();
     }
 }

--- a/presto-orc/src/main/java/io/prestosql/orc/writer/MapColumnWriter.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/writer/MapColumnWriter.java
@@ -142,7 +142,7 @@ public class MapColumnWriter
     {
         checkState(!closed);
 
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null, null);
         rowGroupColumnStatistics.add(statistics);
         nonNullValueCount = 0;
 
@@ -199,7 +199,9 @@ public class MapColumnWriter
         ImmutableList.Builder<StreamDataOutput> indexStreams = ImmutableList.builder();
         indexStreams.add(new StreamDataOutput(slice, stream));
         indexStreams.addAll(keyWriter.getIndexStreams(metadataWriter));
+        indexStreams.addAll(keyWriter.getBloomFilters(metadataWriter));
         indexStreams.addAll(valueWriter.getIndexStreams(metadataWriter));
+        indexStreams.addAll(valueWriter.getBloomFilters(metadataWriter));
         return indexStreams.build();
     }
 
@@ -253,5 +255,12 @@ public class MapColumnWriter
         valueWriter.reset();
         rowGroupColumnStatistics.clear();
         nonNullValueCount = 0;
+    }
+
+    @Override
+    public List<StreamDataOutput> getBloomFilters(CompressedMetadataWriter metadataWriter)
+            throws IOException
+    {
+        return ImmutableList.of();
     }
 }

--- a/presto-orc/src/main/java/io/prestosql/orc/writer/SliceDirectColumnWriter.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/writer/SliceDirectColumnWriter.java
@@ -34,17 +34,20 @@ import io.prestosql.orc.stream.PresentOutputStream;
 import io.prestosql.orc.stream.StreamDataOutput;
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.type.Type;
+import io.prestosql.spi.util.BloomFilter;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.prestosql.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT_V2;
 import static io.prestosql.orc.metadata.CompressionKind.NONE;
 import static io.prestosql.orc.stream.LongOutputStream.createLengthOutputStream;
@@ -225,5 +228,23 @@ public class SliceDirectColumnWriter
         presentStream.reset();
         rowGroupColumnStatistics.clear();
         statisticsBuilder = statisticsBuilderSupplier.get();
+    }
+
+    @Override
+    public List<StreamDataOutput> getBloomFilters(CompressedMetadataWriter metadataWriter)
+            throws IOException
+    {
+        List<BloomFilter> bloomFilters = rowGroupColumnStatistics.stream()
+                .map(ColumnStatistics::getBloomFilter)
+                .filter(Objects::nonNull)
+                .collect(toImmutableList());
+
+        if (!bloomFilters.isEmpty()) {
+            Slice slice = metadataWriter.writeBloomFilters(bloomFilters);
+            Stream stream = new Stream(columnId, StreamKind.BLOOM_FILTER_UTF8, slice.length(), false);
+            return ImmutableList.of(new StreamDataOutput(slice, stream));
+        }
+
+        return ImmutableList.of();
     }
 }

--- a/presto-orc/src/main/java/io/prestosql/orc/writer/StructColumnWriter.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/writer/StructColumnWriter.java
@@ -135,7 +135,7 @@ public class StructColumnWriter
     public Map<OrcColumnId, ColumnStatistics> finishRowGroup()
     {
         checkState(!closed);
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null, null);
         rowGroupColumnStatistics.add(statistics);
         nonNullValueCount = 0;
 
@@ -191,6 +191,7 @@ public class StructColumnWriter
         indexStreams.add(new StreamDataOutput(slice, stream));
         for (ColumnWriter structField : structFields) {
             indexStreams.addAll(structField.getIndexStreams(metadataWriter));
+            indexStreams.addAll(structField.getBloomFilters(metadataWriter));
         }
         return indexStreams.build();
     }
@@ -248,5 +249,12 @@ public class StructColumnWriter
         structFields.forEach(ColumnWriter::reset);
         rowGroupColumnStatistics.clear();
         nonNullValueCount = 0;
+    }
+
+    @Override
+    public List<StreamDataOutput> getBloomFilters(CompressedMetadataWriter metadataWriter)
+            throws IOException
+    {
+        return ImmutableList.of();
     }
 }

--- a/presto-orc/src/test/java/io/prestosql/orc/TestOrcBloomFilters.java
+++ b/presto-orc/src/test/java/io/prestosql/orc/TestOrcBloomFilters.java
@@ -317,6 +317,7 @@ public class TestOrcBloomFilters
                 null,
                 null,
                 null,
+                null,
                 toBloomFilter(orcBloomFilter))));
 
         ColumnMetadata<ColumnStatistics> nonMatchingStatisticsByColumnIndex = new ColumnMetadata<>(ImmutableList.of(new ColumnStatistics(
@@ -329,6 +330,7 @@ public class TestOrcBloomFilters
                 null,
                 null,
                 null,
+                null,
                 toBloomFilter(emptyOrcBloomFilter))));
 
         ColumnMetadata<ColumnStatistics> withoutBloomFilterStatisticsByColumnIndex = new ColumnMetadata<>(ImmutableList.of(new ColumnStatistics(
@@ -336,6 +338,7 @@ public class TestOrcBloomFilters
                 0,
                 null,
                 new IntegerStatistics(10L, 2000L, null),
+                null,
                 null,
                 null,
                 null,

--- a/presto-orc/src/test/java/io/prestosql/orc/TestSliceDictionaryColumnWriter.java
+++ b/presto-orc/src/test/java/io/prestosql/orc/TestSliceDictionaryColumnWriter.java
@@ -16,6 +16,8 @@ package io.prestosql.orc;
 import io.airlift.slice.Slices;
 import io.airlift.units.DataSize;
 import io.prestosql.orc.metadata.CompressionKind;
+import io.prestosql.orc.metadata.statistics.NoOpBloomFilterBuilder;
+import io.prestosql.orc.metadata.statistics.StringStatisticsBuilder;
 import io.prestosql.orc.writer.SliceDictionaryColumnWriter;
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.block.RunLengthEncodedBlock;
@@ -41,7 +43,7 @@ public class TestSliceDictionaryColumnWriter
                 VARCHAR,
                 CompressionKind.NONE,
                 toIntExact(DEFAULT_MAX_COMPRESSION_BUFFER_SIZE.toBytes()),
-                DEFAULT_MAX_STRING_STATISTICS_LIMIT);
+                () -> new StringStatisticsBuilder(toIntExact(DEFAULT_MAX_STRING_STATISTICS_LIMIT.toBytes()), new NoOpBloomFilterBuilder()));
 
         // a single row group exceeds 2G after direct conversion
         byte[] value = new byte[megabytes(1)];

--- a/presto-orc/src/test/java/io/prestosql/orc/TestTupleDomainOrcPredicate.java
+++ b/presto-orc/src/test/java/io/prestosql/orc/TestTupleDomainOrcPredicate.java
@@ -88,7 +88,7 @@ public class TestTupleDomainOrcPredicate
         if (trueValueCount != null) {
             booleanStatistics = new BooleanStatistics(trueValueCount);
         }
-        return new ColumnStatistics(numberOfValues, 2L, booleanStatistics, null, null, null, null, null, null, null);
+        return new ColumnStatistics(numberOfValues, 2L, booleanStatistics, null, null, null, null, null, null, null, null);
     }
 
     @Test
@@ -117,7 +117,7 @@ public class TestTupleDomainOrcPredicate
 
     private static ColumnStatistics integerColumnStats(Long numberOfValues, Long minimum, Long maximum)
     {
-        return new ColumnStatistics(numberOfValues, 9L, null, new IntegerStatistics(minimum, maximum, null), null, null, null, null, null, null);
+        return new ColumnStatistics(numberOfValues, 9L, null, new IntegerStatistics(minimum, maximum, null), null, null, null, null, null, null, null);
     }
 
     @Test
@@ -146,7 +146,7 @@ public class TestTupleDomainOrcPredicate
 
     private static ColumnStatistics doubleColumnStats(Long numberOfValues, Double minimum, Double maximum)
     {
-        return new ColumnStatistics(numberOfValues, 9L, null, null, new DoubleStatistics(minimum, maximum), null, null, null, null, null);
+        return new ColumnStatistics(numberOfValues, 9L, null, null, new DoubleStatistics(minimum, maximum), null, null, null, null, null, null);
     }
 
     @Test
@@ -236,7 +236,7 @@ public class TestTupleDomainOrcPredicate
         Slice minimumSlice = minimum == null ? null : utf8Slice(minimum);
         Slice maximumSlice = maximum == null ? null : utf8Slice(maximum);
         // sum and minAverageValueSizeInBytes are not used in this test; they could be arbitrary numbers
-        return new ColumnStatistics(numberOfValues, 10L, null, null, null, new StringStatistics(minimumSlice, maximumSlice, 100L), null, null, null, null);
+        return new ColumnStatistics(numberOfValues, 10L, null, null, null, new StringStatistics(minimumSlice, maximumSlice, 100L), null, null, null, null, null);
     }
 
     @Test
@@ -265,7 +265,7 @@ public class TestTupleDomainOrcPredicate
 
     private static ColumnStatistics dateColumnStats(Long numberOfValues, Integer minimum, Integer maximum)
     {
-        return new ColumnStatistics(numberOfValues, 5L, null, null, null, null, new DateStatistics(minimum, maximum), null, null, null);
+        return new ColumnStatistics(numberOfValues, 5L, null, null, null, null, new DateStatistics(minimum, maximum), null, null, null, null);
     }
 
     @Test
@@ -321,7 +321,7 @@ public class TestTupleDomainOrcPredicate
     {
         BigDecimal minimumDecimal = minimum == null ? null : new BigDecimal(minimum);
         BigDecimal maximumDecimal = maximum == null ? null : new BigDecimal(maximum);
-        return new ColumnStatistics(numberOfValues, 9L, null, null, null, null, null, new DecimalStatistics(minimumDecimal, maximumDecimal, SHORT_DECIMAL_VALUE_BYTES), null, null);
+        return new ColumnStatistics(numberOfValues, 9L, null, null, null, null, null, null, new DecimalStatistics(minimumDecimal, maximumDecimal, SHORT_DECIMAL_VALUE_BYTES), null, null);
     }
 
     @Test
@@ -343,7 +343,7 @@ public class TestTupleDomainOrcPredicate
     private static ColumnStatistics binaryColumnStats(Long numberOfValues)
     {
         // sum and minAverageValueSizeInBytes are not used in this test; they could be arbitrary numbers
-        return new ColumnStatistics(numberOfValues, 10L, null, null, null, null, null, null, new BinaryStatistics(100L), null);
+        return new ColumnStatistics(numberOfValues, 10L, null, null, null, null, null, null, null, new BinaryStatistics(100L), null);
     }
 
     private static Long shortDecimal(String value)

--- a/presto-orc/src/test/java/io/prestosql/orc/metadata/statistics/AbstractStatisticsBuilderTest.java
+++ b/presto-orc/src/test/java/io/prestosql/orc/metadata/statistics/AbstractStatisticsBuilderTest.java
@@ -171,7 +171,7 @@ public abstract class AbstractStatisticsBuilderTest<B extends StatisticsBuilder,
     static List<ColumnStatistics> insertEmptyColumnStatisticsAt(List<ColumnStatistics> statisticsList, int index, long numberOfValues)
     {
         List<ColumnStatistics> newStatisticsList = new ArrayList<>(statisticsList);
-        newStatisticsList.add(index, new ColumnStatistics(numberOfValues, 0, null, null, null, null, null, null, null, null));
+        newStatisticsList.add(index, new ColumnStatistics(numberOfValues, 0, null, null, null, null, null, null, null, null, null));
         return newStatisticsList;
     }
 

--- a/presto-orc/src/test/java/io/prestosql/orc/metadata/statistics/TestDoubleStatisticsBuilder.java
+++ b/presto-orc/src/test/java/io/prestosql/orc/metadata/statistics/TestDoubleStatisticsBuilder.java
@@ -26,6 +26,9 @@ import static io.prestosql.orc.metadata.statistics.DoubleStatistics.DOUBLE_VALUE
 import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.NaN;
 import static java.lang.Double.POSITIVE_INFINITY;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 public class TestDoubleStatisticsBuilder
         extends AbstractStatisticsBuilderTest<DoubleStatisticsBuilder, Double>
@@ -34,7 +37,7 @@ public class TestDoubleStatisticsBuilder
 
     public TestDoubleStatisticsBuilder()
     {
-        super(DOUBLE, DoubleStatisticsBuilder::new, DoubleStatisticsBuilder::addValue);
+        super(DOUBLE, () -> new DoubleStatisticsBuilder(new NoOpBloomFilterBuilder()), DoubleStatisticsBuilder::addValue);
     }
 
     @Test
@@ -66,7 +69,7 @@ public class TestDoubleStatisticsBuilder
     @Test
     public void testNanValue()
     {
-        DoubleStatisticsBuilder statisticsBuilder = new DoubleStatisticsBuilder();
+        DoubleStatisticsBuilder statisticsBuilder = new DoubleStatisticsBuilder(new NoOpBloomFilterBuilder());
         statisticsBuilder.addValue(NaN);
         assertNoColumnStatistics(statisticsBuilder.buildColumnStatistics(), 1);
         statisticsBuilder.addValue(NaN);
@@ -74,7 +77,7 @@ public class TestDoubleStatisticsBuilder
         statisticsBuilder.addValue(42.42);
         assertNoColumnStatistics(statisticsBuilder.buildColumnStatistics(), 3);
 
-        statisticsBuilder = new DoubleStatisticsBuilder();
+        statisticsBuilder = new DoubleStatisticsBuilder(new NoOpBloomFilterBuilder());
         statisticsBuilder.addValue(42.42);
         assertColumnStatistics(statisticsBuilder.buildColumnStatistics(), 1, 42.42, 42.42);
         statisticsBuilder.addValue(NaN);
@@ -90,5 +93,20 @@ public class TestDoubleStatisticsBuilder
         assertMinAverageValueBytes(DOUBLE_VALUE_BYTES, ImmutableList.of(42D));
         assertMinAverageValueBytes(DOUBLE_VALUE_BYTES, ImmutableList.of(0D));
         assertMinAverageValueBytes(DOUBLE_VALUE_BYTES, ImmutableList.of(0D, 42D, 42D, 43D));
+    }
+
+    @Test
+    public void testUtf8BloomFilter()
+    {
+        DoubleStatisticsBuilder statisticsBuilder = new DoubleStatisticsBuilder(new Utf8BloomFilterBuilder(3, 0.001));
+        statisticsBuilder.addValue(1.23);
+        statisticsBuilder.addValue(45.67);
+        statisticsBuilder.addValue(89.01);
+        HashableBloomFilter hashableBloomFilter = statisticsBuilder.buildColumnStatistics().getBloomFilter();
+        assertNotNull(hashableBloomFilter);
+        assertTrue(hashableBloomFilter.test(1.23));
+        assertTrue(hashableBloomFilter.test(45.67));
+        assertTrue(hashableBloomFilter.test(89.01));
+        assertFalse(hashableBloomFilter.test(100));
     }
 }

--- a/presto-orc/src/test/java/io/prestosql/orc/metadata/statistics/TestIntegerStatisticsBuilder.java
+++ b/presto-orc/src/test/java/io/prestosql/orc/metadata/statistics/TestIntegerStatisticsBuilder.java
@@ -28,14 +28,17 @@ import static io.prestosql.orc.metadata.statistics.IntegerStatistics.INTEGER_VAL
 import static java.lang.Long.MAX_VALUE;
 import static java.lang.Long.MIN_VALUE;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 public class TestIntegerStatisticsBuilder
         extends AbstractStatisticsBuilderTest<IntegerStatisticsBuilder, Long>
 {
     public TestIntegerStatisticsBuilder()
     {
-        super(INTEGER, IntegerStatisticsBuilder::new, IntegerStatisticsBuilder::addValue);
+        super(INTEGER, () -> new IntegerStatisticsBuilder(new NoOpBloomFilterBuilder()), IntegerStatisticsBuilder::addValue);
     }
 
     @Test
@@ -73,7 +76,7 @@ public class TestIntegerStatisticsBuilder
     {
         int values = 0;
         long expectedSum = 0;
-        IntegerStatisticsBuilder integerStatisticsBuilder = new IntegerStatisticsBuilder();
+        IntegerStatisticsBuilder integerStatisticsBuilder = new IntegerStatisticsBuilder(new NoOpBloomFilterBuilder());
         for (int value = -100_000; value < 500_000; value++) {
             values++;
             expectedSum += value;
@@ -85,7 +88,7 @@ public class TestIntegerStatisticsBuilder
     @Test
     public void testSumOverflow()
     {
-        IntegerStatisticsBuilder integerStatisticsBuilder = new IntegerStatisticsBuilder();
+        IntegerStatisticsBuilder integerStatisticsBuilder = new IntegerStatisticsBuilder(new NoOpBloomFilterBuilder());
 
         integerStatisticsBuilder.addValue(MAX_VALUE);
         assertIntegerStatistics(integerStatisticsBuilder.buildColumnStatistics(), 1, MAX_VALUE);
@@ -97,7 +100,7 @@ public class TestIntegerStatisticsBuilder
     @Test
     public void testSumUnderflow()
     {
-        IntegerStatisticsBuilder integerStatisticsBuilder = new IntegerStatisticsBuilder();
+        IntegerStatisticsBuilder integerStatisticsBuilder = new IntegerStatisticsBuilder(new NoOpBloomFilterBuilder());
 
         integerStatisticsBuilder.addValue(MIN_VALUE);
         assertIntegerStatistics(integerStatisticsBuilder.buildColumnStatistics(), 1, MIN_VALUE);
@@ -111,7 +114,7 @@ public class TestIntegerStatisticsBuilder
     {
         List<ColumnStatistics> statisticsList = new ArrayList<>();
 
-        IntegerStatisticsBuilder statisticsBuilder = new IntegerStatisticsBuilder();
+        IntegerStatisticsBuilder statisticsBuilder = new IntegerStatisticsBuilder(new NoOpBloomFilterBuilder());
         statisticsList.add(statisticsBuilder.buildColumnStatistics());
         assertMergedIntegerStatistics(statisticsList, 0, 0L);
 
@@ -137,7 +140,7 @@ public class TestIntegerStatisticsBuilder
     {
         List<ColumnStatistics> statisticsList = new ArrayList<>();
 
-        statisticsList.add(new IntegerStatisticsBuilder().buildColumnStatistics());
+        statisticsList.add(new IntegerStatisticsBuilder(new NoOpBloomFilterBuilder()).buildColumnStatistics());
         assertMergedIntegerStatistics(statisticsList, 0, 0L);
 
         statisticsList.add(singleValueIntegerStatistics(MAX_VALUE));
@@ -149,7 +152,7 @@ public class TestIntegerStatisticsBuilder
 
     private static ColumnStatistics singleValueIntegerStatistics(long value)
     {
-        IntegerStatisticsBuilder statisticsBuilder = new IntegerStatisticsBuilder();
+        IntegerStatisticsBuilder statisticsBuilder = new IntegerStatisticsBuilder(new NoOpBloomFilterBuilder());
         statisticsBuilder.addValue(value);
         return statisticsBuilder.buildColumnStatistics();
     }
@@ -173,5 +176,20 @@ public class TestIntegerStatisticsBuilder
             assertNull(columnStatistics.getIntegerStatistics());
             assertEquals(columnStatistics.getNumberOfValues(), 0);
         }
+    }
+
+    @Test
+    public void testUtf8BloomFilter()
+    {
+        IntegerStatisticsBuilder statisticsBuilder = new IntegerStatisticsBuilder(new Utf8BloomFilterBuilder(3, 0.001));
+        statisticsBuilder.addValue(12);
+        statisticsBuilder.addValue(34);
+        statisticsBuilder.addValue(56);
+        HashableBloomFilter hashableBloomFilter = statisticsBuilder.buildColumnStatistics().getBloomFilter();
+        assertNotNull(hashableBloomFilter);
+        assertTrue(hashableBloomFilter.test(12));
+        assertTrue(hashableBloomFilter.test(34));
+        assertTrue(hashableBloomFilter.test(56));
+        assertFalse(hashableBloomFilter.test(78));
     }
 }

--- a/presto-orc/src/test/java/io/prestosql/orc/metadata/statistics/TestStringStatisticsBuilder.java
+++ b/presto-orc/src/test/java/io/prestosql/orc/metadata/statistics/TestStringStatisticsBuilder.java
@@ -16,6 +16,7 @@ package io.prestosql.orc.metadata.statistics;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
+import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
@@ -28,8 +29,10 @@ import static io.prestosql.orc.metadata.statistics.AbstractStatisticsBuilderTest
 import static io.prestosql.orc.metadata.statistics.ColumnStatistics.mergeColumnStatistics;
 import static io.prestosql.orc.metadata.statistics.StringStatistics.STRING_VALUE_BYTES_OVERHEAD;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 public class TestStringStatisticsBuilder
         extends AbstractStatisticsBuilderTest<StringStatisticsBuilder, Slice>
@@ -48,7 +51,7 @@ public class TestStringStatisticsBuilder
 
     public TestStringStatisticsBuilder()
     {
-        super(STRING, () -> new StringStatisticsBuilder(Integer.MAX_VALUE), StringStatisticsBuilder::addValue);
+        super(STRING, () -> new StringStatisticsBuilder(Integer.MAX_VALUE, new NoOpBloomFilterBuilder()), StringStatisticsBuilder::addValue);
     }
 
     @Test
@@ -93,7 +96,7 @@ public class TestStringStatisticsBuilder
     @Test
     public void testSum()
     {
-        StringStatisticsBuilder stringStatisticsBuilder = new StringStatisticsBuilder(Integer.MAX_VALUE);
+        StringStatisticsBuilder stringStatisticsBuilder = new StringStatisticsBuilder(Integer.MAX_VALUE, new NoOpBloomFilterBuilder());
         for (Slice value : ImmutableList.of(EMPTY_SLICE, LOW_BOTTOM_VALUE, LOW_TOP_VALUE)) {
             stringStatisticsBuilder.addValue(value);
         }
@@ -105,7 +108,7 @@ public class TestStringStatisticsBuilder
     {
         List<ColumnStatistics> statisticsList = new ArrayList<>();
 
-        StringStatisticsBuilder statisticsBuilder = new StringStatisticsBuilder(Integer.MAX_VALUE);
+        StringStatisticsBuilder statisticsBuilder = new StringStatisticsBuilder(Integer.MAX_VALUE, new NoOpBloomFilterBuilder());
         statisticsList.add(statisticsBuilder.buildColumnStatistics());
         assertMergedStringStatistics(statisticsList, 0, 0);
 
@@ -162,7 +165,7 @@ public class TestStringStatisticsBuilder
         // max merged to null
         List<ColumnStatistics> statisticsList = new ArrayList<>();
 
-        StringStatisticsBuilder statisticsBuilder = new StringStatisticsBuilder(7);
+        StringStatisticsBuilder statisticsBuilder = new StringStatisticsBuilder(7, new NoOpBloomFilterBuilder());
         statisticsList.add(statisticsBuilder.buildColumnStatistics());
         assertMergedStringStatistics(statisticsList, 0, 0);
 
@@ -189,7 +192,7 @@ public class TestStringStatisticsBuilder
         // min merged to null
         statisticsList = new ArrayList<>();
 
-        statisticsBuilder = new StringStatisticsBuilder(7);
+        statisticsBuilder = new StringStatisticsBuilder(7, new NoOpBloomFilterBuilder());
         statisticsList.add(statisticsBuilder.buildColumnStatistics());
         assertMergedStringStatistics(statisticsList, 0, 0);
 
@@ -216,7 +219,7 @@ public class TestStringStatisticsBuilder
         // min and max both merged to null
         statisticsList = new ArrayList<>();
 
-        statisticsBuilder = new StringStatisticsBuilder(7);
+        statisticsBuilder = new StringStatisticsBuilder(7, new NoOpBloomFilterBuilder());
         statisticsBuilder.addValue(MEDIUM_BOTTOM_VALUE);
         statisticsList.add(statisticsBuilder.buildColumnStatistics());
         assertMinMax(mergeColumnStatistics(statisticsList).getStringStatistics(), MEDIUM_BOTTOM_VALUE, MEDIUM_BOTTOM_VALUE);
@@ -237,7 +240,7 @@ public class TestStringStatisticsBuilder
     @Test
     public void testCopyStatsToSaveMemory()
     {
-        StringStatisticsBuilder statisticsBuilder = new StringStatisticsBuilder(Integer.MAX_VALUE);
+        StringStatisticsBuilder statisticsBuilder = new StringStatisticsBuilder(Integer.MAX_VALUE, new NoOpBloomFilterBuilder());
         Slice shortSlice = Slices.wrappedBuffer(LONG_BOTTOM_VALUE.getBytes(), 0, 1);
         statisticsBuilder.addValue(shortSlice);
         Slice stats = statisticsBuilder.buildColumnStatistics().getStringStatistics().getMax();
@@ -268,7 +271,7 @@ public class TestStringStatisticsBuilder
     private static void assertMinMaxValuesWithLimit(Slice expectedMin, Slice expectedMax, List<Slice> values, int limit)
     {
         checkArgument(values != null && !values.isEmpty());
-        StringStatisticsBuilder builder = new StringStatisticsBuilder(limit);
+        StringStatisticsBuilder builder = new StringStatisticsBuilder(limit, new NoOpBloomFilterBuilder());
         for (Slice value : values) {
             builder.addValue(value);
         }
@@ -299,6 +302,7 @@ public class TestStringStatisticsBuilder
                 null,
                 null,
                 null,
+                null,
                 null);
     }
 
@@ -312,5 +316,20 @@ public class TestStringStatisticsBuilder
             assertNull(columnStatistics.getStringStatistics());
             assertEquals(columnStatistics.getNumberOfValues(), 0);
         }
+    }
+
+    @Test
+    public void testUtf8BloomFilter()
+    {
+        StringStatisticsBuilder statisticsBuilder = new StringStatisticsBuilder(Integer.MAX_VALUE, new Utf8BloomFilterBuilder(3, 0.001));
+        statisticsBuilder.addValue(LOW_BOTTOM_VALUE);
+        statisticsBuilder.addValue(MEDIUM_BOTTOM_VALUE);
+        statisticsBuilder.addValue(HIGH_BOTTOM_VALUE);
+        HashableBloomFilter hashableBloomFilter = statisticsBuilder.buildColumnStatistics().getBloomFilter();
+        AssertJUnit.assertNotNull(hashableBloomFilter);
+        assertTrue(hashableBloomFilter.test(LOW_BOTTOM_VALUE));
+        assertTrue(hashableBloomFilter.test(MEDIUM_BOTTOM_VALUE));
+        assertTrue(hashableBloomFilter.test(HIGH_BOTTOM_VALUE));
+        assertFalse(hashableBloomFilter.test(HIGH_TOP_VALUE));
     }
 }

--- a/presto-orc/src/test/java/io/prestosql/orc/metadata/statistics/TestTimestampStatistics.java
+++ b/presto-orc/src/test/java/io/prestosql/orc/metadata/statistics/TestTimestampStatistics.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2018-2022. Huawei Technologies Co., Ltd. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.prestosql.orc.metadata.statistics;
+
+import org.openjdk.jol.info.ClassLayout;
+import org.testng.annotations.Test;
+
+import static java.lang.Long.MAX_VALUE;
+import static java.lang.Long.MIN_VALUE;
+
+public class TestTimestampStatistics
+        extends AbstractRangeStatisticsTest<TimestampStatistics, Long>
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(TimestampStatistics.class).instanceSize();
+
+    @Override
+    protected TimestampStatistics getCreateStatistics(Long min, Long max)
+    {
+        return new TimestampStatistics(min, max);
+    }
+
+    @Test
+    public void test()
+    {
+        assertMinMax(0L, 100L);
+        assertMinMax(100L, 100L);
+        assertMinMax(MIN_VALUE, 100L);
+        assertMinMax(100L, MAX_VALUE);
+        assertMinMax(MIN_VALUE, MAX_VALUE);
+    }
+
+    @Test
+    public void testRetainedSize()
+    {
+        assertRetainedSize(0L, 100L, INSTANCE_SIZE);
+        assertRetainedSize(100L, 100L, INSTANCE_SIZE);
+        assertRetainedSize(MIN_VALUE, 100L, INSTANCE_SIZE);
+        assertRetainedSize(100L, MAX_VALUE, INSTANCE_SIZE);
+        assertRetainedSize(MIN_VALUE, MAX_VALUE, INSTANCE_SIZE);
+    }
+}

--- a/presto-spi/src/main/java/io/prestosql/spi/util/BloomFilter.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/util/BloomFilter.java
@@ -237,6 +237,16 @@ public class BloomFilter
         addHash(getLongHash(val));
     }
 
+    public void addDouble(double val)
+    {
+        addLong(doubleToLongBits(val));
+    }
+
+    public void addFloat(float val)
+    {
+        addDouble(val);
+    }
+
     public void add(double val)
     {
         addLong(doubleToLongBits(val));

--- a/presto-tests/src/main/java/io/prestosql/tests/sql/TestTable.java
+++ b/presto-tests/src/main/java/io/prestosql/tests/sql/TestTable.java
@@ -13,11 +13,18 @@
  */
 package io.prestosql.tests.sql;
 
+import java.security.SecureRandom;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.lang.Character.MAX_RADIX;
+import static java.lang.Math.abs;
+import static java.lang.Math.min;
 
 public class TestTable
         implements AutoCloseable
 {
+    private static final SecureRandom RANDOM = new SecureRandom();
+    private static final int RANDOM_SUFFIX_LENGTH = 5;
     private final SqlExecutor sqlExecutor;
     private final String name;
 
@@ -39,5 +46,11 @@ public class TestTable
     public void close()
     {
         sqlExecutor.execute("DROP TABLE " + name);
+    }
+
+    public static String randomTableSuffix()
+    {
+        String randomSuffix = Long.toString(abs(RANDOM.nextLong()), MAX_RADIX);
+        return randomSuffix.substring(0, min(RANDOM_SUFFIX_LENGTH, randomSuffix.length()));
     }
 }


### PR DESCRIPTION
### What type of PR is this?

task

### What does this PR do / why do we need it:

Added bloom index to ORC Files for performance improvement while reading.

- Utf8-Bloom Index Write Support is added in ORC files for Real, Date, Timestamp and Char data types for both transactional and non-transactional tables.
- Read flow modified to skip stripes and row groups in ORC based on bloom index.
- Added Timestamp Statistics to Column Statistics.

### Which issue(s) this PR fixes:

None

### Special notes for your reviewers: