### PR TITLE
To disable unsupported optimizations when snapshot is enabled for query

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/AddExchangeAboveCTENode.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/AddExchangeAboveCTENode.java
@@ -25,6 +25,7 @@ import io.prestosql.sql.planner.iterative.Rule;
 import java.util.Optional;
 
 import static io.prestosql.SystemSessionProperties.isCTEReuseEnabled;
+import static io.prestosql.SystemSessionProperties.isSnapshotEnabled;
 import static io.prestosql.sql.planner.plan.ExchangeNode.Scope.REMOTE;
 import static io.prestosql.sql.planner.plan.ExchangeNode.partitionedExchange;
 import static io.prestosql.sql.planner.plan.Patterns.cteScan;
@@ -40,7 +41,7 @@ public class AddExchangeAboveCTENode
     @Override
     public boolean isEnabled(Session session)
     {
-        return isCTEReuseEnabled(session);
+        return isCTEReuseEnabled(session) && !isSnapshotEnabled(session);
     }
 
     @Override

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/AddReuseExchange.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/AddReuseExchange.java
@@ -50,6 +50,7 @@ import java.util.stream.Collectors;
 import static io.prestosql.SystemSessionProperties.getSpillOperatorThresholdReuseExchange;
 import static io.prestosql.SystemSessionProperties.isColocatedJoinEnabled;
 import static io.prestosql.SystemSessionProperties.isReuseTableScanEnabled;
+import static io.prestosql.SystemSessionProperties.isSnapshotEnabled;
 import static io.prestosql.spi.operator.ReuseExchangeOperator.STRATEGY.REUSE_STRATEGY_CONSUMER;
 import static io.prestosql.spi.operator.ReuseExchangeOperator.STRATEGY.REUSE_STRATEGY_DEFAULT;
 import static io.prestosql.spi.operator.ReuseExchangeOperator.STRATEGY.REUSE_STRATEGY_PRODUCER;
@@ -78,7 +79,7 @@ public class AddReuseExchange
         requireNonNull(planSymbolAllocator, "symbolAllocator is null");
         requireNonNull(idAllocator, "idAllocator is null");
 
-        if (!isReuseTableScanEnabled(session) || isColocatedJoinEnabled(session)) {
+        if (!isReuseTableScanEnabled(session) || isColocatedJoinEnabled(session) || isSnapshotEnabled(session)) {
             return plan;
         }
         else {

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/AddSortBasedAggregation.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/AddSortBasedAggregation.java
@@ -55,6 +55,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static io.prestosql.SystemSessionProperties.isSnapshotEnabled;
 import static io.prestosql.SystemSessionProperties.isSortBasedAggregationEnabled;
 import static io.prestosql.spi.plan.TableScanNode.getActualColName;
 import static io.prestosql.sql.planner.plan.ChildReplacer.replaceChildren;
@@ -80,7 +81,7 @@ public class AddSortBasedAggregation
     @Override
     public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, PlanSymbolAllocator planSymbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
     {
-        if (!isSortBasedAggregationEnabled(session)) {
+        if (!isSortBasedAggregationEnabled(session) || isSnapshotEnabled(session)) {
             return plan;
         }
 


### PR DESCRIPTION
### What type of PR is this?

task

### What does this PR do / why do we need it:

Few optimizations are not supported for snapshot, so disabling them when running query with snapshot enabled. 

### Which issue(s) this PR fixes:


### Special notes for your reviewers: