### PR TITLE
Fixed infinite loop while refreshing node states before reschedling.

### DIFF
--- a/presto-main/src/main/java/io/prestosql/failuredetector/HeartbeatFailureDetector.java
+++ b/presto-main/src/main/java/io/prestosql/failuredetector/HeartbeatFailureDetector.java
@@ -510,7 +510,7 @@ public class HeartbeatFailureDetector
                 lastCompleteTimestamp = System.nanoTime();
                 lastFailureCount = stats.getRecentFailures();
             }
-            else if (Duration.nanosSince(lastCompleteTimestamp).compareTo(new Duration(1, TimeUnit.SECONDS)) > 0 && stats.getRecentFailures() == lastFailureCount) {
+            else if (Duration.nanosSince(lastCompleteTimestamp).compareTo(new Duration(1, TimeUnit.SECONDS)) > 0 && stats.getRecentFailures() <= lastFailureCount) {
                 lastCompleteTimestamp = System.nanoTime();
             }
         }


### PR DESCRIPTION
### What type of PR is this?
bug

### What does this PR do / why do we need it:
Fixed infinite loop while refreshing node states before reschedling

### Which issue(s) this PR fixes:

Fixes #I50RW0

### Special notes for your reviewers:
To consder nodes which are recovered from failures before, we should update timestamp if failurecount is less than first failure count stored at the time of recovery