### PR TITLE
Update PrestoS3FileSystem.java

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/PrestoS3FileSystem.java
@@ -419,7 +419,7 @@ public class PrestoS3FileSystem
         }
         catch (FileNotFoundException e) {
             // destination does not exist
-            LOG.debug("destination does not exist");
+            log.debug("destination does not exist");
         }
 
         if (keysEqual(src, dstPath)) {


### PR DESCRIPTION
The `LOG.debug("destination does not exist");` should be `log.debug("destination does not exist");`， because the `LOG` is parent FileSystem's reference.

### What type of PR is this?
bug
### What does this PR do / why do we need it:
When use LOG to print some messages, The log class of log message is not the current  `PrestoS3FileSystem`, but the parent FileSystem.
### Which issue(s) this PR fixes:

Fixes #

### Special notes for your reviewers: