### PR TITLE
Ut for cache operators

### DIFF
--- a/presto-main/src/test/java/io/prestosql/operator/TestCacheTableFinishOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestCacheTableFinishOperator.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.Slice;
+import io.prestosql.Session;
+import io.prestosql.execution.TableExecuteContext;
+import io.prestosql.execution.TableExecuteContextManager;
+import io.prestosql.spi.QueryId;
+import io.prestosql.spi.connector.ConnectorOutputMetadata;
+import io.prestosql.spi.plan.PlanNodeId;
+import io.prestosql.spi.statistics.ColumnStatisticMetadata;
+import io.prestosql.spi.statistics.ComputedStatistics;
+import io.prestosql.spi.type.Type;
+import io.prestosql.sql.planner.plan.StatisticAggregationsDescriptor;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.prestosql.RowPagesBuilder.rowPagesBuilder;
+import static io.prestosql.operator.PageAssertions.assertPageEquals;
+import static io.prestosql.spi.statistics.ColumnStatisticType.MAX_VALUE;
+import static io.prestosql.spi.type.BigintType.BIGINT;
+import static io.prestosql.testing.TestingSession.testSessionBuilder;
+import static io.prestosql.testing.TestingTaskContext.createTaskContext;
+import static java.util.concurrent.Executors.newScheduledThreadPool;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+@Test(singleThreaded = true)
+public class TestCacheTableFinishOperator
+{
+    private ScheduledExecutorService scheduledExecutor;
+
+    @BeforeClass
+    public void setUp()
+    {
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        scheduledExecutor.shutdownNow();
+        scheduledExecutor = null;
+    }
+
+    @Test
+    public void testCacheTableFinishOperator()
+    {
+        TestCacheTableFinisher testCacheTableFinisher = new TestCacheTableFinisher();
+        CacheTableFinishOperator operator = createCacheTableFinishOperator(testCacheTableFinisher);
+
+        assertFalse(operator.isFinished());
+        assertTrue(operator.needsInput());
+        operator.addInput(rowPagesBuilder(BIGINT).row(1).build().get(0));
+
+        assertFalse(operator.isFinished());
+        assertTrue(operator.needsInput());
+
+        // add second page
+        operator.addInput(rowPagesBuilder(BIGINT).row(2).build().get(0));
+
+        assertFalse(operator.isFinished());
+        assertTrue(operator.needsInput());
+
+        // finish operator, state hasn't changed
+        operator.finish();
+        assertFalse(operator.isFinished());
+        assertFalse(operator.needsInput());
+
+        // and getOutput which actually finishes the operator
+        List<Type> expectedTypes = ImmutableList.of(BIGINT);
+        assertPageEquals(expectedTypes,
+                operator.getOutput(),
+                rowPagesBuilder(expectedTypes).row(1).build().get(0));
+        assertPageEquals(expectedTypes,
+                operator.getOutput(),
+                rowPagesBuilder(expectedTypes).row(2).build().get(0));
+
+        assertNull(operator.getOutput()); // no more pages will be returned. state should move to FINISHED.
+
+        assertTrue(operator.isFinished());
+        assertTrue(testCacheTableFinisher.isFinished());
+        assertFalse(operator.needsInput());
+    }
+
+    private CacheTableFinishOperator createCacheTableFinishOperator(TestCacheTableFinisher testCacheTableFinisher)
+    {
+        Session session = testSessionBuilder().build();
+        ColumnStatisticMetadata statisticMetadata = new ColumnStatisticMetadata("column", MAX_VALUE);
+        StatisticAggregationsDescriptor<Integer> descriptor = new StatisticAggregationsDescriptor<>(
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                ImmutableMap.of(statisticMetadata, 0));
+        io.prestosql.execution.TableExecuteContextManager tableExecuteContextManager = new TableExecuteContextManager();
+        tableExecuteContextManager.registerTableExecuteContextForQuery(QueryId.valueOf("test_query"));
+        DriverContext driverContext = createTaskContext(scheduledExecutor, scheduledExecutor, session)
+                .addPipelineContext(0, true, true, false)
+                .addDriverContext();
+        CacheTableFinishOperator.CacheTableFinishOperatorFactory cacheTableFinishOperatorFactory = new CacheTableFinishOperator.CacheTableFinishOperatorFactory(0,
+                new PlanNodeId("test"),
+                testCacheTableFinisher,
+                descriptor,
+                tableExecuteContextManager,
+                session,
+                100000,
+                (endtime, size) -> null,
+                () -> null);
+        return (CacheTableFinishOperator) cacheTableFinishOperatorFactory.createOperator(driverContext);
+    }
+
+    private static class TestCacheTableFinisher
+            implements TableFinishOperator.TableFinisher
+    {
+        private boolean finished;
+        private Collection<Slice> fragments;
+        private Collection<ComputedStatistics> computedStatistics;
+
+        @Override
+        public Optional<ConnectorOutputMetadata> finishTable(Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics, TableExecuteContext tableExecuteContext)
+        {
+            checkState(!finished, "already finished");
+            finished = true;
+            this.fragments = fragments;
+            this.computedStatistics = computedStatistics;
+            return Optional.empty();
+        }
+
+        public Collection<Slice> getFragments()
+        {
+            return fragments;
+        }
+
+        public Collection<ComputedStatistics> getComputedStatistics()
+        {
+            return computedStatistics;
+        }
+
+        public boolean isFinished()
+        {
+            return finished;
+        }
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/operator/TestCacheTableWriterOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestCacheTableWriterOperator.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import io.prestosql.Session;
+import io.prestosql.metadata.OutputTableHandle;
+import io.prestosql.spi.Page;
+import io.prestosql.spi.connector.CatalogName;
+import io.prestosql.spi.connector.ConnectorInsertTableHandle;
+import io.prestosql.spi.connector.ConnectorOutputTableHandle;
+import io.prestosql.spi.connector.ConnectorPageSink;
+import io.prestosql.spi.connector.ConnectorPageSinkProvider;
+import io.prestosql.spi.connector.ConnectorSession;
+import io.prestosql.spi.connector.ConnectorTransactionHandle;
+import io.prestosql.spi.connector.SchemaTableName;
+import io.prestosql.spi.plan.PlanNodeId;
+import io.prestosql.spi.type.Type;
+import io.prestosql.split.PageSinkManager;
+import io.prestosql.sql.planner.plan.TableWriterNode;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.prestosql.RowPagesBuilder.rowPagesBuilder;
+import static io.prestosql.SessionTestUtils.TEST_SESSION;
+import static io.prestosql.operator.PageAssertions.assertPageEquals;
+import static io.prestosql.spi.type.BigintType.BIGINT;
+import static io.prestosql.testing.TestingTaskContext.createTaskContext;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static java.util.concurrent.Executors.newScheduledThreadPool;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+public class TestCacheTableWriterOperator
+{
+    private static final CatalogName CONNECTOR_ID = new CatalogName("testConnectorId");
+    private ExecutorService executor;
+    private ScheduledExecutorService scheduledExecutor;
+
+    @BeforeClass
+    public void setUp()
+    {
+        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        executor.shutdownNow();
+        scheduledExecutor.shutdownNow();
+    }
+
+    @Test
+    public void testBlockedPageSink()
+    {
+        CacheWriterBlockingPageSink blockingPageSink = new CacheWriterBlockingPageSink();
+        Operator operator = createCacheTableWriterOperator(blockingPageSink);
+
+        // initial state validation
+        assertTrue(operator.isBlocked().isDone());
+        assertFalse(operator.isFinished());
+        assertTrue(operator.needsInput());
+
+        // blockingPageSink that will return blocked future
+        operator.addInput(rowPagesBuilder(BIGINT).row(42).build().get(0));
+
+        assertFalse(operator.isBlocked().isDone());
+        assertFalse(operator.isFinished());
+        assertFalse(operator.needsInput());
+        assertNull(operator.getOutput());
+
+        // complete previously blocked future
+        blockingPageSink.complete();
+
+        assertTrue(operator.isBlocked().isDone());
+        assertFalse(operator.isFinished());
+        assertTrue(operator.needsInput());
+
+        // add second page
+        operator.addInput(rowPagesBuilder(BIGINT).row(44).build().get(0));
+
+        assertFalse(operator.isBlocked().isDone());
+        assertFalse(operator.isFinished());
+        assertFalse(operator.needsInput());
+
+        // finish operator, state hasn't changed
+        operator.finish();
+
+        assertFalse(operator.isBlocked().isDone());
+        assertFalse(operator.isFinished());
+        assertFalse(operator.needsInput());
+
+        // complete previously blocked future
+        blockingPageSink.complete();
+        // and getOutput which actually finishes the operator
+        List<Type> expectedTypes = ImmutableList.of(BIGINT);
+        assertPageEquals(expectedTypes,
+                operator.getOutput(),
+                rowPagesBuilder(expectedTypes).row(42).build().get(0));
+
+        assertTrue(operator.isBlocked().isDone());
+
+        assertPageEquals(expectedTypes,
+                operator.getOutput(),
+                rowPagesBuilder(expectedTypes).row(44).build().get(0));
+
+        assertNull(operator.getOutput());
+
+        assertTrue(operator.isBlocked().isDone());
+        assertTrue(operator.isFinished());
+        assertFalse(operator.needsInput());
+    }
+
+    private Operator createCacheTableWriterOperator(CacheWriterBlockingPageSink blockingPageSink)
+    {
+        PageSinkManager pageSinkManager = new PageSinkManager();
+        pageSinkManager.addConnectorPageSinkProvider(CONNECTOR_ID, new CacheWriterConstantPageSinkProvider(blockingPageSink));
+        return createCacheTableWriterOperator(pageSinkManager);
+    }
+
+    private Operator createCacheTableWriterOperator(PageSinkManager pageSinkManager)
+    {
+        return createCacheTableWriterOperator(pageSinkManager, TEST_SESSION);
+    }
+
+    private Operator createCacheTableWriterOperator(PageSinkManager pageSinkManager, Session session)
+    {
+        DriverContext driverContext = createTaskContext(executor, scheduledExecutor, session)
+                .addPipelineContext(0, true, true, false)
+                .addDriverContext();
+        return createCacheTableWriterOperator(pageSinkManager, session, driverContext);
+    }
+
+    private Operator createCacheTableWriterOperator(
+            PageSinkManager pageSinkManager,
+            Session session,
+            DriverContext driverContext)
+    {
+        CacheTableWriterOperator.CacheTableWriterOperatorFactory factory = new CacheTableWriterOperator.CacheTableWriterOperatorFactory(0,
+                new PlanNodeId("test"),
+                pageSinkManager,
+                new TableWriterNode.CreateTarget(new OutputTableHandle(
+                        CONNECTOR_ID,
+                        new ConnectorTransactionHandle() {},
+                        new ConnectorOutputTableHandle() {}),
+                        new SchemaTableName("testSchema", "testTable")),
+                ImmutableList.of(0),
+                session,
+                Optional.empty(),
+                1000000);
+        return factory.createOperator(driverContext);
+    }
+
+    private static class CacheWriterConstantPageSinkProvider
+            implements ConnectorPageSinkProvider
+    {
+        private final ConnectorPageSink pageSink;
+
+        private CacheWriterConstantPageSinkProvider(ConnectorPageSink pageSink)
+        {
+            this.pageSink = pageSink;
+        }
+
+        @Override
+        public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorOutputTableHandle outputTableHandle)
+        {
+            return pageSink;
+        }
+
+        @Override
+        public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorInsertTableHandle insertTableHandle)
+        {
+            return pageSink;
+        }
+    }
+
+    private static class CacheWriterBlockingPageSink
+            implements ConnectorPageSink
+    {
+        private CompletableFuture<?> future = new CompletableFuture<>();
+        private CompletableFuture<Collection<Slice>> finishFuture = new CompletableFuture<>();
+
+        @Override
+        public CompletableFuture<?> appendPage(Page page)
+        {
+            future = new CompletableFuture<>();
+            return future;
+        }
+
+        @Override
+        public CompletableFuture<Collection<Slice>> finish()
+        {
+            finishFuture = new CompletableFuture<>();
+            return finishFuture;
+        }
+
+        @Override
+        public void abort()
+        {
+        }
+
+        void complete()
+        {
+            future.complete(null);
+            finishFuture.complete(ImmutableList.of());
+        }
+    }
+}


### PR DESCRIPTION
### What type of PR is this?

Uncomment only one /kind <> line, hit enter to put that in a new line, and remove leading whitespaces from that line:

kind task
### What does this PR do / why do we need it: This adds UT for Cache Table Operators

### Which issue(s) this PR fixes:

Fixes #405

### Special notes for your reviewers: