### PR TITLE
solve java.lang.ClassCastException

### DIFF
--- a/presto-main/src/main/java/io/prestosql/execution/resourcegroups/DistributedResourceGroupTemp.java
+++ b/presto-main/src/main/java/io/prestosql/execution/resourcegroups/DistributedResourceGroupTemp.java
@@ -683,7 +683,7 @@ public class DistributedResourceGroupTemp
             }
             updateLocalValuesToStateStore();
             for (BaseResourceGroup group : subGroups.values()) {
-                ((InternalResourceGroup) group).internalGenerateCpuQuota(elapsedSeconds);
+                ((DistributedResourceGroupTemp) group).internalGenerateCpuQuota(elapsedSeconds);
             }
         }
     }


### PR DESCRIPTION
### What type of PR is this?
bug

### What does this PR do / why do we need it:
when enable muti cordinator and use children resource groups, we encouter a ClassCastException of:  io.prestosql.execution.resourcegroups.DistributedResourceGroupTemp cannot be cast to io.prestosql.execution.resourcegroups.InternalResourceGroup

### Which issue(s) this PR fixes:

Fixes #

### Special notes for your reviewers: